### PR TITLE
adding python-msp430-bsl telosb fork for tmotesky

### DIFF
--- a/meta-iotlab/recipes-core/packagegroups/gateway-packagegroup.bb
+++ b/meta-iotlab/recipes-core/packagegroups/gateway-packagegroup.bb
@@ -9,6 +9,7 @@ RDEPENDS_${PN} += " \
     flash-scripts-gateway \
     gateway-code \
     cc2538-bsl \
+    msp430-bsl \
     ftdi-utils \
     initrdscripts-mountgw \
     root-sshd-ssh-keys-gw \

--- a/meta-iotlab/recipes-devtools/msp430-bsl/python-msp430-bsl_git.bb
+++ b/meta-iotlab/recipes-devtools/msp430-bsl/python-msp430-bsl_git.bb
@@ -1,0 +1,16 @@
+DESCRIPTION = "msp430-bsl script fork for telosB used for tmotesky"
+HOMEPAGE = "https://github.com/cetic/python-msp430-tools"
+SECTION = "console"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3f35f76815f8f56319273610675d2758"
+
+PR = "r1"
+
+PV = "git-src${SRCDATE}-r${SRCPV}"
+
+SRC_URI = "git://github.com/cetic/python-msp430-tools.git;protocol=https"
+SRCREV = "${AUTOREV}"
+
+S = "${WORKDIR}/git"
+
+inherit setuptools


### PR DESCRIPTION
bsl to flash tmotesky/telosb, from a fork on my repo from https://github.com/cetic/python-msp430-tools, maybe we'd put it somewhere else ?