### PR TITLE
add nghttp2 library support

### DIFF
--- a/meta-iotlab/recipes-connectivity/libev/libev_4.24.bb
+++ b/meta-iotlab/recipes-connectivity/libev/libev_4.24.bb
@@ -1,0 +1,22 @@
+SUMMARY = "A full-featured and high-performance event loop that is loosely \
+modelled after libevent."
+HOMEPAGE = "http://software.schmorp.de/pkg/libev.html"
+LICENSE = "BSD-2-Clause | GPL-2.0+"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=d6ad416afd040c90698edcdf1cbee347"
+
+SRC_URI = "http://dist.schmorp.de/libev/Attic/${BP}.tar.gz"
+
+SRC_URI[md5sum] = "94459a5a22db041dec6f98424d6efe54"
+SRC_URI[sha256sum] = "973593d3479abdf657674a55afe5f78624b0e440614e2b8cb3a07f16d4d7f821"
+
+S = "${WORKDIR}/${PN}-${PV}"
+
+inherit autotools
+
+EXTRA_OECONF += "--with-pic"
+
+do_install_append() {
+    # Avoid conflicting with libevent. The provided compatibility layer is
+    # still basic so drop it for now.
+    rm ${D}${includedir}/event.h
+}

--- a/meta-iotlab/recipes-connectivity/wpantund/wpantund_0.07.01.bb
+++ b/meta-iotlab/recipes-connectivity/wpantund/wpantund_0.07.01.bb
@@ -5,9 +5,9 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS += "autoconf-archive-native"
-DEPENDS += "dbus readline"
+DEPENDS += "dbus readline boost"
 
-RDEPENDS_${PN} += "dbus readline"
+RDEPENDS_${PN} += "dbus readline boost"
 
 SRC_URI  = "git://github.com/openthread/wpantund.git;protocol=https"
 # Tag full/0.07.01 based on this commit

--- a/meta-iotlab/recipes-core/images/iotlab-image.inc
+++ b/meta-iotlab/recipes-core/images/iotlab-image.inc
@@ -116,6 +116,22 @@ IMAGE_INSTALL += "              \
         bash                    \
         bind-utils              \
         oml2-dev                \
+        jansson                 \
+        jansson-dev             \
+        c-ares                  \
+        c-ares-dev              \
+        libev                   \
+        libev-dev               \
+        libevent                \
+        libevent-dev            \
+        boost                   \
+        boost-dev               \
+        jemalloc                \
+        jemalloc-dev            \
+        cunit                   \
+        cunit-dev               \
+        openssl                 \
+        openssl-dev             \
         \
         \
         \

--- a/meta-iotlab/recipes-core/packagegroups/open-a8-packagegroup.bb
+++ b/meta-iotlab/recipes-core/packagegroups/open-a8-packagegroup.bb
@@ -17,6 +17,11 @@ RDEPENDS_${PN} += " \
     python-numpy \
     python-intelhex \
     "
+# nghttp2 package depedencies
+RDEPENDS_${PN} += " \
+    python-cython \
+    python3-cython \
+    "
 
 RDEPENDS_${PN} += " \
     base-packagegroup \

--- a/meta-iotlab/recipes-extended/jansson/jansson_2.10.bb
+++ b/meta-iotlab/recipes-extended/jansson/jansson_2.10.bb
@@ -1,0 +1,12 @@
+SUMMARY = "Jansson is a C library for encoding, decoding and manipulating JSON data"
+HOMEPAGE = "http://www.digip.org/jansson/"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=8b70213ec164c7bd876ec2120ba52f61"
+
+SRC_URI = "http://www.digip.org/jansson/releases/${PN}-${PV}.tar.gz"
+
+SRC_URI[md5sum] = "16a2c4e84c0a80ca61bd6e619a0f9358"
+SRC_URI[sha256sum] = "78215ad1e277b42681404c1d66870097a50eb084be9d771b1d15576575cf6447"
+
+inherit autotools pkgconfig
+

--- a/meta-iotlab/recipes-support/c-ares/c-ares_1.13.0.bb
+++ b/meta-iotlab/recipes-support/c-ares/c-ares_1.13.0.bb
@@ -1,0 +1,14 @@
+# Copyright (c) 2012-2014 LG Electronics, Inc.
+
+DESCRIPTION = "c-ares is a C library that resolves names asynchronously."
+HOMEPAGE = "http://daniel.haxx.se/projects/c-ares/"
+SECTION = "libs"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://ares_init.c;beginline=1;endline=3;md5=53f5ecf4c22c37cf1ddd1ef8f8eccce0"
+
+SRC_URI = "http://c-ares.haxx.se/download/${BP}.tar.gz"
+SRC_URI[md5sum] = "d2e010b43537794d8bedfb562ae6bba2"
+SRC_URI[sha256sum] = "03f708f1b14a26ab26c38abd51137640cb444d3ec72380b21b20f1a8d2861da7"
+
+inherit autotools pkgconfig
+

--- a/meta-iotlab/recipes-support/jemalloc/jemalloc_4.0.4.bb
+++ b/meta-iotlab/recipes-support/jemalloc/jemalloc_4.0.4.bb
@@ -1,0 +1,34 @@
+SUMMARY = "A general purpose malloc(3) implementation that emphasizes fragmentation avoidance and scalable concurrency support."
+HOMEPAGE = "https://github.com/jemalloc/jemalloc"
+
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://COPYING;md5=5cff9c9987190d1c1ab7ba635c1d9f29"
+
+PV="4.0.4"
+SRC_URI = "https://github.com/jemalloc/jemalloc/releases/download/${PV}/jemalloc-${PV}.tar.bz2"
+SRC_URI[md5sum] = "687c5cc53b9a7ab711ccd680351ff988"
+SRC_URI[sha256sum] = "3fda8d8d7fcd041aa0bebbecd45c46b28873cf37bd36c56bf44961b36d0f42d0"
+
+inherit autotools
+
+FILES_${PN} = "/usr/lib/libjemalloc.so.2"
+
+FILES_${PN}-dev = "/usr/lib/libjemalloc.a \
+    /usr/lib/libjemalloc.so "
+
+PROVIDES="${PACKAGES}"
+
+do_configure (){
+    oe_runconf
+}
+
+do_compile (){
+    oe_runmake build_lib_shared
+}
+
+do_install() {
+    oe_runmake DESTDIR=${D} install_lib_shared
+    rm -fr ${D}/usr/src/debug/jemalloc
+}
+
+BBCLASSEXTEND = "lib_package"

--- a/meta-iotlab/recipes-support/libevent/libevent/run-ptest
+++ b/meta-iotlab/recipes-support/libevent/libevent/run-ptest
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+fail=0
+for test in ./test/*
+do
+	$test
+	if [ $? -eq 0 ]
+	then
+		fail=1
+	fi
+done
+
+if [ $fail -eq 0 ]
+then
+	echo "PASS: libevent"
+else
+	echo "FAIL: libevent"
+fi

--- a/meta-iotlab/recipes-support/libevent/libevent_2.0.22.bb
+++ b/meta-iotlab/recipes-support/libevent/libevent_2.0.22.bb
@@ -1,0 +1,41 @@
+SUMMARY = "An asynchronous event notification library"
+HOMEPAGE = "http://libevent.org/"
+BUGTRACKER = "http://sourceforge.net/tracker/?group_id=50884&atid=461322"
+SECTION = "libs"
+
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=45c5316ff684bcfe2f9f86d8b1279559"
+
+SRC_URI = " \
+    ${SOURCEFORGE_MIRROR}/levent/${BP}-stable.tar.gz \
+    file://run-ptest \
+"
+
+SRC_URI[md5sum] = "c4c56f986aa985677ca1db89630a2e11"
+SRC_URI[sha256sum] = "71c2c49f0adadacfdbe6332a372c38cf9c8b7895bb73dabeaa53cdcc1d4e1fa3"
+
+UPSTREAM_CHECK_URI = "http://libevent.org/"
+
+S = "${WORKDIR}/${BPN}-${PV}-stable"
+
+PACKAGECONFIG ??= " openssl"
+PACKAGECONFIG[openssl] = "--enable-openssl,--disable-openssl,openssl"
+
+inherit autotools
+
+# Needed for Debian packaging
+LEAD_SONAME = "libevent-2.0.so"
+
+inherit ptest
+
+DEPENDS = "zlib"
+
+BBCLASSEXTEND = "native nativesdk"
+
+do_install_ptest() {
+	install -d ${D}${PTEST_PATH}/test
+	for file in ${B}/test/.libs/regress ${B}/test/.libs/test*
+	do
+		install -m 0755 $file ${D}${PTEST_PATH}/test
+	done
+}


### PR DESCRIPTION
   * install requirements: https://www.nghttp2.org/documentation/package_README.html#requirements
   * add packages: libev(-dev), jansson(-dev), c-ares(-dev), jemalloc(-dev), libevent(-dev)
     boost(-dev), cunit(-dev), python(3)-cython
   * fix wpantund recipe with boost package depedency