### PR TITLE
include intelhex in yocto image for firefly

### DIFF
--- a/meta-iotlab/recipes-core/images/iotlab-image.inc
+++ b/meta-iotlab/recipes-core/images/iotlab-image.inc
@@ -57,6 +57,7 @@ IMAGE_INSTALL +="               \
         python-setuptools       \
         python-pip              \
         python-magic            \
+        python-intelhex         \
         python3                 \
         python3-pyserial        \
         python3-dev             \

--- a/meta-iotlab/recipes-core/packagegroups/open-a8-packagegroup.bb
+++ b/meta-iotlab/recipes-core/packagegroups/open-a8-packagegroup.bb
@@ -15,7 +15,6 @@ RDEPENDS_${PN} += " \
     python-hkdf \
     python-pycryptodome \
     python-numpy \
-    python-intelhex \
     "
 
 RDEPENDS_${PN} += " \


### PR DESCRIPTION
Forgot to include intelhex in the installed recipes in yocto, which is needed for the firefly support