### PR TITLE
Add support for Raspberry PI3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
+build-rpi3/
 .idea/

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,7 @@
 	path = meta-java
 	url = git://git.yoctoproject.org/meta-java
 	branch = krogoth
+[submodule "meta-raspberrypi"]
+	path = meta-raspberrypi
+	url = git://git.yoctoproject.org/meta-raspberrypi
+	branch = krogoth

--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,18 @@ submodules:
 # Building images and packages targets  #
 # # # # # # # # # # # # # # # # # # # # #
 
-.PHONY: build-all build-img-% iotlab-image-%
+.PHONY: target-info build-all build-img-% iotlab-image-%
 
-list-images:
-	@for img in $(IMAGES); do echo $$img; done;
+target-info:
+	@echo Using target: $(TARGET)
+	@echo ""
+	@echo "Available image targets:"
+	@for img in $(IMAGES); do echo "  - $$img"; done;
+	@if [ ! -z "$(EXTRA_BUILDS)" ]; \
+	then \
+	echo "\nOther build targets:"; \
+	for target in $(EXTRA_BUILDS); do echo "  - $$target"; done; \
+	fi
 
 build-all: $(IMAGES) $(EXTRA_BUILDS)
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ TARGET ?= a8
 IMAGES = iotlab-image
 IMAGES += iotlab-image-gateway
 
+EXTRA_BUILDS =
+
 # Define variables specific to the given target
 ifeq ($(TARGET), a8)
   BUILD_DIR = build
@@ -22,6 +24,9 @@ ifeq ($(TARGET), a8)
   # A8 also has an autotest image
   iotlab-image-autotest = iotlab-image-open-a8-autotest
   IMAGES += iotlab-image-autotest
+
+  # We also build uboot and a mtd-rw version of the kernel for A8
+  EXTRA_BUILDS = build-uboot build-kernel-mtd-rw
 else ifeq ($(TARGET), rpi3)
   BUILD_DIR = build-rpi3
   TARGET_ARCH = cortexa7hf-neon-vfpv4
@@ -56,10 +61,10 @@ submodules:
 
 .PHONY: build-all build-img-% iotlab-image-%
 
-list-images: init
+list-images:
 	@for img in $(IMAGES); do echo $$img; done;
 
-build-all: $(IMAGES) build-uboot build-kernel-mtd-rw
+build-all: $(IMAGES) $(EXTRA_BUILDS)
 
 $(IMAGES): %: build-img-% clean-img-%
 

--- a/Makefile
+++ b/Makefile
@@ -80,23 +80,23 @@ $(IMAGES): %: build-img-% clean-img-%
 build-pkg-%:
 	@# build package
 	time bash -c \
-                "source ./poky/oe-init-build-env $(BUILD_DIR); bitbake -k $($*)"
+                "source ./poky/oe-init-build-env $(BUILD_DIR); bitbake -k $*"
 	@echo ""
 	@echo ""
-	ackage files should be found here:
-	ls $(PKGS_DIR)
+	@echo "$*" ipk package files should be found here:
+	@ls $(PKGS_DIR)/$**
 
 .PHONY: build-pkg-%-native
 build-pkg-%-native: init
 	@# build native package
 	time bash -c \
-                "source ./poky/oe-init-build-env $(BUILD_DIR); bitbake -k $($*)-native"
+                "source ./poky/oe-init-build-env $(BUILD_DIR); bitbake -k $*-native"
 
 .PHONY: clean-pkg-%
 clean-pkg-%: init
 	@# clean package
 	time bash -c \
-                "source ./poky/oe-init-build-env $(BUILD_DIR); bitbake -c cleanall $($*)"
+                "source ./poky/oe-init-build-env $(BUILD_DIR); bitbake -c cleanall $*"
 
 .PHONY: build-uboot
 build-uboot: init
@@ -106,8 +106,8 @@ build-uboot: init
 	@echo ""
 	@echo ""
 	@echo "$*" U-Boot files should be found here:
-	ls $(IMGS_DIR)/u-boot*
-	ls $(IMGS_DIR)/MLO*
+	@ls $(IMGS_DIR)/u-boot*
+	@ls $(IMGS_DIR)/MLO*
 
 .PHONY: clean-uboot
 clean-uboot: init
@@ -123,7 +123,7 @@ build-kernel: init
 	@echo ""
 	@echo ""
 	@echo "$*" Kernel files should be found here:
-	ls $(IMGS_DIR)/$(KERNEL_IMG)*
+	@ls $(IMGS_DIR)/$(KERNEL_IMG)*
 
 .PHONY: clean-kernel
 clean-kernel: init
@@ -139,7 +139,7 @@ build-kernel-mtd-rw: init
 	@echo ""
 	@echo ""
 	@echo "$*" Kernel mtd writeable files should be found here:
-	ls $(IMGS_MTD_RW_DIR)/$(KERNEL_IMG)*
+	@ls $(IMGS_MTD_RW_DIR)/$(KERNEL_IMG)*
 
 .PHONY: clean-kernel-mtd-rw
 clean-kernel-mtd-rw: init
@@ -155,7 +155,7 @@ build-img-%: init
 	@echo ""
 	@echo ""
 	@echo "$*" image files should be found here:
-	ls $(IMGS_DIR)/$**
+	@ls $(IMGS_DIR)/$**
 
 .PHONY: clean-img-%
 clean-img-%:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To build images you can run:
 
     $ make build-all 
     # or one by one
-    $ make iotlab-image-open-a8
+    $ make iotlab-image
 
 > Do NOT attempt to build on an encrypted partition ecryptfs limits filename length to 150 characters.
 

--- a/build-rpi3/conf/bblayers.conf
+++ b/build-rpi3/conf/bblayers.conf
@@ -1,0 +1,21 @@
+# LAYER_CONF_VERSION is increased each time build/conf/bblayers.conf
+# changes incompatibly
+POKY_BBLAYERS_CONF_VERSION = "2"
+
+BBPATH = "${TOPDIR}"
+BBFILES ?= ""
+
+BBLAYERS ?= " \
+  ${TOPDIR}/../poky/meta \
+  ${TOPDIR}/../poky/meta-poky \
+  ${TOPDIR}/../meta-openembedded/meta-oe \
+  ${TOPDIR}/../meta-openembedded/meta-networking \
+  ${TOPDIR}/../meta-openembedded/meta-python \
+  ${TOPDIR}/../meta-java/ \
+  ${TOPDIR}/../meta-iotlab/ \
+  ${TOPDIR}/../meta-raspberrypi/ \
+  "
+BBLAYERS_NON_REMOVABLE ?= " \
+  ${TOPDIR}/../poky/meta \
+  ${TOPDIR}/../poky/meta-poky \
+  "

--- a/build-rpi3/conf/local.conf
+++ b/build-rpi3/conf/local.conf
@@ -1,0 +1,103 @@
+LICENSE_FLAGS_WHITELIST = "IoT-LAB"
+DISTRO ?= "iotlab"
+
+# local repository with sources
+SOURCE_MIRROR_URL ?= "file://${TOPDIR}/../downloads/"
+INHERIT += "own-mirrors"
+BB_GENERATE_MIRROR_TARBALLS = "1"
+# BB_NO_NETWORK = "1"
+
+# cleanup after build of sources
+INHERIT += "rm_work"
+
+# Enable console
+ENABLE_UART = "1"
+
+MACHINE ??= "qemuarm"
+MACHINE ?= "raspberrypi3"
+
+# Where to place downloads
+#DL_DIR ?= "${TOPDIR}/downloads"
+
+# Where to place shared-state files
+#SSTATE_DIR ?= "${TOPDIR}/sstate-cache"
+
+# Where to place the build output
+#TMPDIR = "${TOPDIR}/tmp"
+
+# Package Management configuration
+PACKAGE_CLASSES ?= "package_ipk"
+
+BB_NUMBER_THREADS ?= "8"
+PARALLEL_MAKE ?= "-j 8"
+
+# Extra image configuration defaults
+#
+# The EXTRA_IMAGE_FEATURES variable allows extra packages to be added to the generated 
+# images. Some of these options are added to certain image types automatically. The
+# variable can contain the following options:
+#  "dbg-pkgs"       - add -dbg packages for all installed packages
+#                     (adds symbol information for debugging/profiling)
+#  "dev-pkgs"       - add -dev packages for all installed packages
+#                     (useful if you want to develop against libs in the image)
+#  "ptest-pkgs"     - add -ptest packages for all ptest-enabled packages
+#                     (useful if you want to run the package test suites)
+#  "tools-sdk"      - add development tools (gcc, make, pkgconfig etc.)
+#  "tools-debug"    - add debugging tools (gdb, strace)
+#  "eclipse-debug"  - add Eclipse remote debugging support
+#  "tools-profile"  - add profiling tools (oprofile, exmap, lttng, valgrind)
+#  "tools-testapps" - add useful testing tools (ts_print, aplay, arecord etc.)
+#  "debug-tweaks"   - make an image suitable for development
+#                     e.g. ssh root access has a blank password
+# There are other application targets that can be used here too, see
+# meta/classes/image.bbclass and meta/classes/core-image.bbclass for more details.
+# We default to enabling the debugging tweaks.
+#EXTRA_IMAGE_FEATURES = "read-only-rootfs"
+EXTRA_IMAGE_FEATURES = ""
+
+#
+# Additional image features
+#
+# The following is a list of additional classes to use when building images which
+# enable extra features. Some available options which can be included in this variable 
+# are:
+#   - 'buildstats' collect build statistics
+#   - 'image-mklibs' to reduce shared library files size for an image
+#   - 'image-prelink' in order to prelink the filesystem image
+#   - 'image-swab' to perform host system intrusion detection
+# NOTE: if listing mklibs & prelink both, then make sure mklibs is before prelink
+# NOTE: mklibs also needs to be explicitly enabled for a given image, see local.conf.extended
+USER_CLASSES ?= "buildstats image-mklibs image-prelink"
+
+# Interactive shell configuration
+PATCHRESOLVE = "noop"
+
+# Disk Space Monitoring during the build
+#
+# Monitor the disk space during the build. If there is less that 1GB of space or less
+# than 100K inodes in any key build location (TMPDIR, DL_DIR, SSTATE_DIR), gracefully
+# shutdown the build. If there is less that 100MB or 1K inodes, perform a hard abort
+# of the build. The reason for this is that running completely out of space can corrupt
+# files and damages the build in ways which may not be easily recoverable.
+BB_DISKMON_DIRS = "\
+    STOPTASKS,${TMPDIR},1G,100K \
+    STOPTASKS,${DL_DIR},1G,100K \
+    STOPTASKS,${SSTATE_DIR},1G,100K \
+    ABORT,${TMPDIR},100M,1K \
+    ABORT,${DL_DIR},100M,1K \
+    ABORT,${SSTATE_DIR},100M,1K" 
+
+# CONF_VERSION is increased each time build/conf/ changes incompatibly and is used to
+# track the version of this file when it was generated. This can safely be ignored if
+# this doesn't mean anything to you.
+CONF_VERSION = "1"
+
+GLIBC_GENERATE_LOCALES = "en_GB.UTF-8 en_US.UTF-8"
+
+### OpenJDK Preferences
+# Possible provider: cacao-initial-native and jamvm-initial-native
+PREFERRED_PROVIDER_virtual/java-initial-native = "cacao-initial-native"
+# Possible provider: cacao-native and jamvm-native
+PREFERRED_PROVIDER_virtual/java-native = "jamvm-native"
+# Optional since there is only one provider for now
+PREFERRED_PROVIDER_virtual/javac-native = "ecj-bootstrap-native"

--- a/build-rpi3/conf/local.conf
+++ b/build-rpi3/conf/local.conf
@@ -19,6 +19,8 @@ MACHINE ?= "raspberrypi3"
 # use compressed image 
 KERNEL_IMAGETYPE = "zImage"
 
+IMAGE_FSTYPES += "tar.gz"
+
 # prefer Linux 4.4
 PREFERRED_VERSION_linux-raspberrypi ?= "4.4%"
 

--- a/build-rpi3/conf/local.conf
+++ b/build-rpi3/conf/local.conf
@@ -16,6 +16,12 @@ ENABLE_UART = "1"
 MACHINE ??= "qemuarm"
 MACHINE ?= "raspberrypi3"
 
+# use compressed image 
+KERNEL_IMAGETYPE = "zImage"
+
+# prefer Linux 4.4
+PREFERRED_VERSION_linux-raspberrypi ?= "4.4%"
+
 # Where to place downloads
 #DL_DIR ?= "${TOPDIR}/downloads"
 

--- a/build-rpi3/conf/sanity_info
+++ b/build-rpi3/conf/sanity_info
@@ -1,0 +1,4 @@
+SANITY_VERSION 1
+TMPDIR /data/yocto/iot-lab-yocto/build-rpi3/tmp
+SSTATE_DIR /data/yocto/iot-lab-yocto/build-rpi3/sstate-cache
+NATIVELSBSTRING CentOS-7.2.1511

--- a/build-rpi3/conf/sanity_info
+++ b/build-rpi3/conf/sanity_info
@@ -1,4 +1,0 @@
-SANITY_VERSION 1
-TMPDIR /data/yocto/iot-lab-yocto/build-rpi3/tmp
-SSTATE_DIR /data/yocto/iot-lab-yocto/build-rpi3/sstate-cache
-NATIVELSBSTRING CentOS-7.2.1511

--- a/build-rpi3/conf/templateconf.cfg
+++ b/build-rpi3/conf/templateconf.cfg
@@ -1,0 +1,1 @@
+meta-poky/conf

--- a/build-rpi3/conf/templateconf.cfg
+++ b/build-rpi3/conf/templateconf.cfg
@@ -1,1 +1,0 @@
-meta-poky/conf

--- a/build/conf/bblayers.conf
+++ b/build/conf/bblayers.conf
@@ -13,6 +13,7 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-openembedded/meta-python \
   ${TOPDIR}/../meta-java/ \
   ${TOPDIR}/../meta-iotlab/ \
+  ${TOPDIR}/../meta-raspberrypi/ \
   "
 BBLAYERS_NON_REMOVABLE ?= " \
   ${TOPDIR}/../poky/meta \

--- a/build/conf/bblayers.conf
+++ b/build/conf/bblayers.conf
@@ -13,7 +13,6 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-openembedded/meta-python \
   ${TOPDIR}/../meta-java/ \
   ${TOPDIR}/../meta-iotlab/ \
-  ${TOPDIR}/../meta-raspberrypi/ \
   "
 BBLAYERS_NON_REMOVABLE ?= " \
   ${TOPDIR}/../poky/meta \

--- a/meta-iotlab/conf/layer.conf
+++ b/meta-iotlab/conf/layer.conf
@@ -6,4 +6,4 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
 
 BBFILE_COLLECTIONS += "iotlab"
 BBFILE_PATTERN_iotlab = "^${LAYERDIR}"
-BBFILE_PRIORITY_iotlab = "8"
+BBFILE_PRIORITY_iotlab = "10"

--- a/meta-iotlab/recipes-core/images/iotlab-image-gateway-rpi3.bb
+++ b/meta-iotlab/recipes-core/images/iotlab-image-gateway-rpi3.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "IoT-LAB image for Open A8 used by users"
+include iotlab-image.inc
+
+# Include modules in rootfs
+IMAGE_INSTALL += " \
+    kernel-modules \
+    gateway-packagegroup \
+	"

--- a/meta-iotlab/recipes-core/images/iotlab-image-gateway.bb
+++ b/meta-iotlab/recipes-core/images/iotlab-image-gateway.bb
@@ -1,4 +1,7 @@
 DESCRIPTION = "IoT-LAB image for Gateways"
 include iotlab-image.inc
 
-IMAGE_INSTALL += "gateway-packagegroup"
+IMAGE_INSTALL += " \
+        gateway-packagegroup \
+        u-boot-fw-utils \
+        "

--- a/meta-iotlab/recipes-core/images/iotlab-image-open-a8.bb
+++ b/meta-iotlab/recipes-core/images/iotlab-image-open-a8.bb
@@ -1,4 +1,8 @@
 DESCRIPTION = "IoT-LAB image for Open A8 used by users"
 include iotlab-image.inc
 
-IMAGE_INSTALL += "open-a8-packagegroup"
+IMAGE_INSTALL += " \
+        open-a8-packagegroup \
+        u-boot-fw-utils \
+        "
+

--- a/meta-iotlab/recipes-core/images/iotlab-image-rpi3.bb
+++ b/meta-iotlab/recipes-core/images/iotlab-image-rpi3.bb
@@ -1,0 +1,7 @@
+include iotlab-image.inc
+
+# Include modules in rootfs
+IMAGE_INSTALL += " \
+	kernel-modules \
+	"
+

--- a/meta-iotlab/recipes-core/images/iotlab-image.inc
+++ b/meta-iotlab/recipes-core/images/iotlab-image.inc
@@ -35,7 +35,6 @@ DISTRO_FEATURES += "nfs ipv6"
 
 IMAGE_INSTALL +="               \
         lsb                     \
-        u-boot-fw-utils         \
         tzdata                  \
         cronie                  \
         logrotate               \


### PR DESCRIPTION
This PR adds support in Yocto for the Raspberry PI3 board.

For the moment, it's possible to use it as a gateway but with no control node. For this gateway setup, basic features has been tested: start/stop an experiment, flash a board, serial redirection.

**How to build images and package**

In this PR, the base Makefile has been modified to easily manage the builds of A8 and RPI3 boards (or targets). I just had to make the choice of renaming the target images - iotlab-image-open-a8 and iotlab-image-open-a8-autotest - to more generic names : iotlab-image and iotlab-image-autotest. iotlab-image-gateway is kept unchanged.

To summarize, building things using make can be done like this:
```
# Build the gateway image for a8:
make iotlab-image-gateway
# Build the open-a8 image:
make iotlab-image
# Build the open-a8 autotest image (not yet available for RPI3):
make iotlab-image-autotest
# Build the gateway image for Raspberry PI3:
make TARGET=rpi3 iotlab-image-gateway
# Build the open linux image for Raspberry PI3:
make TARGET=rpi3 iotlab-image
```

A8 target has extra builds available: uboot and build-kernel-mtd-rw

For each target, one can build all targets with following calls:
```
# For A8 (this hasn't changed):
make build-all
# For Raspberry PI3:
make TARGET=rpi3 build-all
```

With recent changes in install-lib, the use of Raspberry PI3 as a gateway is now working (without control nodes: no monitoring available).