### PR TITLE
Install openvpn by default on open-a8 images

### DIFF
--- a/meta-iotlab/recipes-core/packagegroups/open-a8-packagegroup.bb
+++ b/meta-iotlab/recipes-core/packagegroups/open-a8-packagegroup.bb
@@ -37,6 +37,7 @@ RDEPENDS_${PN} += " \
     nodejs \
     openjdk-8 \
     openjre-8 \
+    openvpn \
     python-paho-mqtt \
     wpantund \
     "


### PR DESCRIPTION
Some people during Silecs spring shool were asking to have this installed on the Open A8. In fact, it's just a matter of building the package since it's already provided by the openembedded layer.

This PR is just adding it to the open-a8-packagegroup. Maybe it's not that useful.