### PR TITLE
meta-iotlab: add and update recipes required by pytest 

### DIFF
--- a/meta-iotlab/recipes-devtools/python/python-atomicwrites_1.1.5.bb
+++ b/meta-iotlab/recipes-devtools/python/python-atomicwrites_1.1.5.bb
@@ -1,0 +1,13 @@
+## -*-conf-*-
+DESCRIPTION = "Atomic file writes."
+HOMEPAGE = "https://pypi.python.org/pypi/atomicwrites"
+SECTION = "devel/python"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=91cc36cfafeefb7863673bcfcb1d4da4"
+
+PR = "r0"
+
+SRC_URI[md5sum] = "2669c1222f2886cab9a1f1d6370d47da"
+SRC_URI[sha256sum] = "240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585"
+
+inherit pypi setuptools

--- a/meta-iotlab/recipes-devtools/python/python-attrs_18.1.0.bb
+++ b/meta-iotlab/recipes-devtools/python/python-attrs_18.1.0.bb
@@ -1,0 +1,13 @@
+## -*-conf-*-
+DESCRIPTION = "Classes Without Boilerplate"
+HOMEPAGE = "https://pypi.python.org/pypi/attrs"
+SECTION = "devel/python"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=d4ab25949a73fe7d4fdee93bcbdbf8ff"
+
+PR = "r0"
+
+SRC_URI[md5sum] = "3f3f3e0750dab74cfa1dc8b0fd7a5f86"
+SRC_URI[sha256sum] = "e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
+
+inherit pypi setuptools

--- a/meta-iotlab/recipes-devtools/python/python-beautifulsoup4_4.6.0.bb
+++ b/meta-iotlab/recipes-devtools/python/python-beautifulsoup4_4.6.0.bb
@@ -1,0 +1,13 @@
+## -*-conf-*-
+DESCRIPTION = "Screen-scraping library"
+HOMEPAGE = "https://pypi.python.org/pypi/beautifulsoup4"
+SECTION = "devel/python"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://COPYING.txt;md5=f2d38d8a40bf73fd4b3d16ca2e5882d1"
+
+PR = "r0"
+
+SRC_URI[md5sum] = "c17714d0f91a23b708a592cb3c697728"
+SRC_URI[sha256sum] = "808b6ac932dccb0a4126558f7dfdcf41710dd44a4ef497a0bb59a77f9f078e89"
+
+inherit pypi setuptools

--- a/meta-iotlab/recipes-devtools/python/python-funcsigs_1.0.2.bb
+++ b/meta-iotlab/recipes-devtools/python/python-funcsigs_1.0.2.bb
@@ -1,0 +1,18 @@
+SUMMARY = "Python function signatures from PEP362 for Python 2.6, 2.7 and 3.2+"
+DESCRPTION = " \
+funcsigs is a backport of the `PEP 362`_ function signature features from \
+Python 3.3's `inspect`_ module. The backport is compatible with Python 2.6, \
+2.7 as well as 3.3 and up. 3.2 was supported by version 0.4, but with \
+setuptools and pip no longer supporting 3.2, we cannot make any statement \
+about 3.2 compatibility. \
+"
+
+HOMEPAGE = "http://funcsigs.readthedocs.org"
+SECTION = "devel/python"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=d6bc91dc8e5793892189fe7481a2d354"
+
+SRC_URI[md5sum] = "7e583285b1fb8a76305d6d68f4ccc14e"
+SRC_URI[sha256sum] = "a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
+
+inherit pypi setuptools

--- a/meta-iotlab/recipes-devtools/python/python-logilab-common_1.4.1.bb
+++ b/meta-iotlab/recipes-devtools/python/python-logilab-common_1.4.1.bb
@@ -1,0 +1,14 @@
+DESCRIPTION = "collection of low-level Python packages and modules used by Logilab projects"
+SECTION = "devel/python"
+LICENSE = "LGPL-2.1"
+LIC_FILES_CHKSUM = "file://COPYING.LESSER;md5=2d5025d4aa3495befef8f17206a5b0a1"
+
+SRCNAME = "logilab-common"
+RDEPENDS_${PN} = "python-six"
+
+SRC_URI = "https://files.pythonhosted.org/packages/5b/ad/a4020c78d0bf3bacf7f039176943367f912700221160c180c74346aa6c4a/${SRCNAME}-${PV}.tar.gz"
+SRC_URI[md5sum] = "e1419b1e73caf63a2c3125fc567ac113"
+SRC_URI[sha256sum] = "ed1c60f32c3fa03dc2efaa730e606db1209d14b4769561ff0365aa584a29360a"
+
+S = "${WORKDIR}/${SRCNAME}-${PV}"
+inherit setuptools

--- a/meta-iotlab/recipes-devtools/python/python-logilab-common_1.4.1.bb
+++ b/meta-iotlab/recipes-devtools/python/python-logilab-common_1.4.1.bb
@@ -6,9 +6,8 @@ LIC_FILES_CHKSUM = "file://COPYING.LESSER;md5=2d5025d4aa3495befef8f17206a5b0a1"
 SRCNAME = "logilab-common"
 RDEPENDS_${PN} = "python-six"
 
-SRC_URI = "https://files.pythonhosted.org/packages/5b/ad/a4020c78d0bf3bacf7f039176943367f912700221160c180c74346aa6c4a/${SRCNAME}-${PV}.tar.gz"
 SRC_URI[md5sum] = "e1419b1e73caf63a2c3125fc567ac113"
 SRC_URI[sha256sum] = "ed1c60f32c3fa03dc2efaa730e606db1209d14b4769561ff0365aa584a29360a"
 
 S = "${WORKDIR}/${SRCNAME}-${PV}"
-inherit setuptools
+inherit pypi setuptools

--- a/meta-iotlab/recipes-devtools/python/python-more-itertools_4.2.0.bb
+++ b/meta-iotlab/recipes-devtools/python/python-more-itertools_4.2.0.bb
@@ -1,0 +1,13 @@
+## -*-conf-*-
+DESCRIPTION = "More routines for operating on iterables, beyond itertools"
+HOMEPAGE = "https://pypi.python.org/pypi/more-itertools"
+SECTION = "devel/python"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3396ea30f9d21389d7857719816f83b5"
+
+PR = "r0"
+
+SRC_URI[md5sum] = "5629c955d17df328ec534989f0649369"
+SRC_URI[sha256sum] = "2b6b9893337bfd9166bee6a62c2b0c9fe7735dcf85948b387ec8cba30e85d8e8"
+
+inherit pypi setuptools

--- a/meta-iotlab/recipes-devtools/python/python-pluggy_0.6.0.bb
+++ b/meta-iotlab/recipes-devtools/python/python-pluggy_0.6.0.bb
@@ -1,0 +1,13 @@
+## -*-conf-*-
+DESCRIPTION = "plugin and hook calling mechanisms for python"
+HOMEPAGE = "https://pypi.python.org/pypi/pluggy/"
+SECTION = "devel/python"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=338dad807ed9337bfaeb9979c3bfe20f"
+
+PR = "r0"
+
+SRC_URI[md5sum] = "ffdde7c3a5ba9a440404570366ffb6d5"
+SRC_URI[sha256sum] = "7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff"
+
+inherit pypi setuptools

--- a/meta-iotlab/recipes-devtools/python/python-py_1.5.3.bb
+++ b/meta-iotlab/recipes-devtools/python/python-py_1.5.3.bb
@@ -1,0 +1,13 @@
+## -*-conf-*-
+DESCRIPTION = "py: library with cross-python path, ini-parsing, io, code, log facilities"
+HOMEPAGE = "https://pypi.python.org/pypi/py/"
+SECTION = "devel/python"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=a6bb0320b04a0a503f12f69fea479de9"
+
+SRC_URI[md5sum] = "667d37a148ad9fb81266492903f2d880"
+SRC_URI[sha256sum] = "29c9fab495d7528e80ba1e343b958684f4ace687327e6f789a94bf3d1915f881"
+
+RDEPENDS_${PN} = "python"
+
+inherit pypi setuptools

--- a/meta-iotlab/recipes-devtools/python/python-pytest-cov_2.5.1.bb
+++ b/meta-iotlab/recipes-devtools/python/python-pytest-cov_2.5.1.bb
@@ -1,0 +1,14 @@
+## -*-conf-*-
+DESCRIPTION = "pytest-cov: Pytest plugin for measuring coverage."
+HOMEPAGE = "https://pypi.python.org/pypi/pytest-cov/"
+SECTION = "devel/python"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=cbc4e25353c748c817db2daffe605e43"
+
+PR = "r0"
+SRC_URI[md5sum] = "5acf38d4909e19819eb5c1754fbfc0ac"
+SRC_URI[sha256sum] = "03aa752cf11db41d281ea1d807d954c4eda35cfa1b21d6971966cc041bbf6e2d"
+
+RDEPENDS_${PN} = "python-pytest"
+
+inherit pypi setuptools

--- a/meta-iotlab/recipes-devtools/python/python-pytest_3.6.2.bb
+++ b/meta-iotlab/recipes-devtools/python/python-pytest_3.6.2.bb
@@ -6,8 +6,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c39b24965f4aef64222cb35de9d47cc4"
 
 PR = "r0"
-SRCNAME = "pytest"
-SRC_URI = "https://pypi.python.org/packages/source/p/${SRCNAME}/${SRCNAME}-${PV}.tar.gz"
+
 SRC_URI[md5sum] = "f773f6fd2e093f59a0939be028e570b3"
 SRC_URI[sha256sum] = "8ea01fc4fcc8e1b1e305252b4bc80a1528019ab99fd3b88666c9dc38d754406c"
 
@@ -17,8 +16,7 @@ RDEPENDS_${PN}_class-target += " \
     ${PYTHON_PN}-argparse \
     ${PYTHON_PN}-compiler \
     ${PYTHON_PN}-funcsigs \
+    ${PYTHON_PN}-pluggy \
 "
 
-S = "${WORKDIR}/${SRCNAME}-${PV}"
-
-inherit setuptools
+inherit pypi setuptools

--- a/meta-iotlab/recipes-devtools/python/python-pytest_3.6.2.bb
+++ b/meta-iotlab/recipes-devtools/python/python-pytest_3.6.2.bb
@@ -10,13 +10,17 @@ PR = "r0"
 SRC_URI[md5sum] = "f773f6fd2e093f59a0939be028e570b3"
 SRC_URI[sha256sum] = "8ea01fc4fcc8e1b1e305252b4bc80a1528019ab99fd3b88666c9dc38d754406c"
 
-RDEPENDS_${PN} = "python-py python-contextlib"
-
 RDEPENDS_${PN}_class-target += " \
     ${PYTHON_PN}-argparse \
+    ${PYTHON_PN}-atomicwrites \
+    ${PYTHON_PN}-attrs \
     ${PYTHON_PN}-compiler \
+    ${PYTHON_PN}-contextlib \
     ${PYTHON_PN}-funcsigs \
+    ${PYTHON_PN}-more-itertools \
     ${PYTHON_PN}-pluggy \
+    ${PYTHON_PN}-py \
+    ${PYTHON_PN}-six \
 "
 
 inherit pypi setuptools

--- a/meta-iotlab/recipes-devtools/python/python-pytest_3.6.2.bb
+++ b/meta-iotlab/recipes-devtools/python/python-pytest_3.6.2.bb
@@ -13,6 +13,12 @@ SRC_URI[sha256sum] = "8ea01fc4fcc8e1b1e305252b4bc80a1528019ab99fd3b88666c9dc38d7
 
 RDEPENDS_${PN} = "python-py python-contextlib"
 
+RDEPENDS_${PN}_class-target += " \
+    ${PYTHON_PN}-argparse \
+    ${PYTHON_PN}-compiler \
+    ${PYTHON_PN}-funcsigs \
+"
+
 S = "${WORKDIR}/${SRCNAME}-${PV}"
 
 inherit setuptools

--- a/meta-iotlab/recipes-devtools/python/python-pytest_3.6.2.bb
+++ b/meta-iotlab/recipes-devtools/python/python-pytest_3.6.2.bb
@@ -1,0 +1,18 @@
+## -*-conf-*-
+DESCRIPTION = "pytest: simple powerful testing with Python"
+HOMEPAGE = "https://pypi.python.org/pypi/pytest/"
+SECTION = "devel/python"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=c39b24965f4aef64222cb35de9d47cc4"
+
+PR = "r0"
+SRCNAME = "pytest"
+SRC_URI = "https://pypi.python.org/packages/source/p/${SRCNAME}/${SRCNAME}-${PV}.tar.gz"
+SRC_URI[md5sum] = "f773f6fd2e093f59a0939be028e570b3"
+SRC_URI[sha256sum] = "8ea01fc4fcc8e1b1e305252b4bc80a1528019ab99fd3b88666c9dc38d754406c"
+
+RDEPENDS_${PN} = "python-py python-contextlib"
+
+S = "${WORKDIR}/${SRCNAME}-${PV}"
+
+inherit setuptools

--- a/meta-iotlab/recipes-devtools/python/python-six_1.11.0.bb
+++ b/meta-iotlab/recipes-devtools/python/python-six_1.11.0.bb
@@ -1,0 +1,9 @@
+DESCRIPTION = "Python 2 and 3 compatibility utilities"
+SECTION = "devel/python"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=35cec5bf04dd0820d0a18533ea7c774a"
+
+SRC_URI[md5sum] = "d12789f9baf7e9fb2524c0c64f1773f8"
+SRC_URI[sha256sum] = "70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
+
+inherit pypi setuptools

--- a/meta-iotlab/recipes-devtools/python/python-waitress_1.1.0.bb
+++ b/meta-iotlab/recipes-devtools/python/python-waitress_1.1.0.bb
@@ -1,0 +1,13 @@
+## -*-conf-*-
+DESCRIPTION = "Waitress WSGI server"
+HOMEPAGE = "https://pypi.python.org/pypi/waitress/"
+SECTION = "devel/python"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=78ccb3640dc841e1baecb3e27a6966b2"
+
+PR = "r0"
+
+SRC_URI[md5sum] = "0f1eb7fdfdbf2e6d18decbda1733045c"
+SRC_URI[sha256sum] = "d33cd3d62426c0f1b3cd84ee3d65779c7003aae3fc060dee60524d10a57f05a9"
+
+inherit pypi setuptools

--- a/meta-iotlab/recipes-devtools/python/python-webob_1.8.2.bb
+++ b/meta-iotlab/recipes-devtools/python/python-webob_1.8.2.bb
@@ -1,0 +1,15 @@
+## -*-conf-*-
+DESCRIPTION = "WSGI request and response object"
+HOMEPAGE = "https://pypi.python.org/pypi/WebOb/"
+SECTION = "devel/python"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+PR = "r0"
+
+PYPI_PACKAGE = "WebOb"
+
+SRC_URI[md5sum] = "d04756e6683fedddba52eafbe9adf404"
+SRC_URI[sha256sum] = "1fe722f2ab857685fc96edec567dc40b1875b21219b3b348e58cd8c4d5ea7df3"
+
+inherit pypi setuptools

--- a/meta-iotlab/recipes-devtools/python/python-webtest_2.0.30.bb
+++ b/meta-iotlab/recipes-devtools/python/python-webtest_2.0.30.bb
@@ -1,0 +1,21 @@
+## -*-conf-*-
+DESCRIPTION = "Helper to test WSGI applications"
+HOMEPAGE = "https://pypi.python.org/pypi/WebTest/"
+SECTION = "devel/python"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+PR = "r0"
+
+PYPI_PACKAGE = "WebTest"
+
+SRC_URI[md5sum] = "0dd5a9093922e08e452f60d7d2eae99a"
+SRC_URI[sha256sum] = "5c69f73cc58bef355e919ff96054b68cbaecc7d970b60b602568d3d92ca967d5"
+
+RDEPENDS_${PN}_class-target += " \
+    ${PYTHON_PN}-webob \
+    ${PYTHON_PN}-waitress \
+    ${PYTHON_PN}-beautifulsoup4 \
+"
+
+inherit pypi setuptools

--- a/meta-iotlab/recipes-support/gateway-code/gateway-code_git.bb
+++ b/meta-iotlab/recipes-support/gateway-code/gateway-code_git.bb
@@ -24,6 +24,8 @@ RDEPENDS_${PN} += "python-mock python-pep8"
 RDEPENDS_${PN} += "python-pylint"
 RDEPENDS_${PN} += "python-tox (>= 1.8.0)"
 RDEPENDS_${PN} += "python-testfixtures"
+RDEPENDS_${PN} += "python-pytest"
+RDEPENDS_${PN} += "python-pytest-cov"
 
 PV = "git-src${SRCDATE}-r${SRCPV}"
 

--- a/meta-iotlab/recipes-support/gateway-code/gateway-code_git.bb
+++ b/meta-iotlab/recipes-support/gateway-code/gateway-code_git.bb
@@ -26,6 +26,7 @@ RDEPENDS_${PN} += "python-tox (>= 1.8.0)"
 RDEPENDS_${PN} += "python-testfixtures"
 RDEPENDS_${PN} += "python-pytest"
 RDEPENDS_${PN} += "python-pytest-cov"
+RDEPENDS_${PN} += "python-webtest"
 
 PV = "git-src${SRCDATE}-r${SRCPV}"
 


### PR DESCRIPTION
This PR adds and updates several recipes required to perform integration tests using pytest on iotlab gateways:
- update python-six, logilab-common (because of a conflict with pytest in older version), python-py
- add attrs, atomicwrites, funcsigs, pluggy, more-itertools, required by pytest
- add pytest and pytest-cov
- pytest and pytest-cov are added as new dependency to gateway_code
- add recipe for WebTest and related dependencies (beautifulsoup4, WebOb, waitress)

The idea behind this is to use site packages when running the integration tests. This has 2 advantages: we ensure the integration tests are run in a "as close as possible to real" environment, this speeds up quite a bit the setup phase (when creating the tox environment).

The build is passing and a prebuilt image is deployed on several CI nodes.