### PR TITLE
Add rtl-sdr support in RPI3 gateway image

### DIFF
--- a/meta-iotlab/recipes-core/images/iotlab-image-gateway-rpi3.bb
+++ b/meta-iotlab/recipes-core/images/iotlab-image-gateway-rpi3.bb
@@ -8,4 +8,5 @@ IMAGE_INSTALL += " \
     mjpg-streamer \
     hub-ctrl \
     sudo \
+    rtl-sdr \
 	"

--- a/meta-iotlab/recipes-support/gateway-code/gateway-code_git.bb
+++ b/meta-iotlab/recipes-support/gateway-code/gateway-code_git.bb
@@ -50,6 +50,7 @@ INITSCRIPT_NAME = "gateway-server-daemon"
 INITSCRIPT_PARAMS = "start 80 2 3 4 5 . stop 20 0 1 6 ."
 FILES_${PN} += "${sysconfdir}/init.d/gateway-server-daemon"
 FILES_${PN} += "${sysconfdir}/init.d/mjpg-streamer-daemon"
+FILES_${PN} += "${sysconfdir}/init.d/rtl-tcp-daemon"
 do_install_append () {
     install -d                               ${D}${sysconfdir}/udev/rules.d/
     install -m 0644 ${S}/bin/rules.d/*.rules ${D}${sysconfdir}/udev/rules.d/
@@ -57,6 +58,7 @@ do_install_append () {
     install -d                                                 ${D}${sysconfdir}/init.d/
     install -m 0755 ${S}/bin/init_script/gateway-server-daemon ${D}${sysconfdir}/init.d/gateway-server-daemon
     install -m 0755 ${S}/bin/init_script/mjpg-streamer-daemon ${D}${sysconfdir}/init.d/mjpg-streamer-daemon
+    install -m 0755 ${S}/bin/init_script/rtl-tcp-daemon ${D}${sysconfdir}/init.d/rtl-tcp-daemon
 
     install -d                       ${D}${bindir}
     install -m 0755 ${WORKDIR}/stop_dc_on  ${D}${bindir}/

--- a/meta-iotlab/recipes-support/rtl-sdr/files/0001-Do-not-store-build-system-CFLAGS-in-the-pkgconfig-fi.patch
+++ b/meta-iotlab/recipes-support/rtl-sdr/files/0001-Do-not-store-build-system-CFLAGS-in-the-pkgconfig-fi.patch
@@ -1,0 +1,25 @@
+From db61c2ea6ddc0cf0ef04c79593e1a76174c93dd1 Mon Sep 17 00:00:00 2001
+From: Philip Balister <philip@balister.org>
+Date: Fri, 12 Feb 2016 13:06:33 -0500
+Subject: [PATCH] Do not store build system CFLAGS in the pkgconfig file.
+
+Signed-off-by: Philip Balister <philip@balister.org>
+---
+ librtlsdr.pc.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/librtlsdr.pc.in b/librtlsdr.pc.in
+index 5e55049..c879f68 100644
+--- a/librtlsdr.pc.in
++++ b/librtlsdr.pc.in
+@@ -6,6 +6,6 @@ includedir=@includedir@
+ Name: RTL-SDR Library
+ Description: C Utility Library
+ Version: @VERSION@
+-Cflags: -I${includedir}/ @RTLSDR_PC_CFLAGS@
++Cflags: -I${includedir}/
+ Libs: -L${libdir} -lrtlsdr -lusb-1.0
+ Libs.private: @RTLSDR_PC_LIBS@
+-- 
+2.5.0
+

--- a/meta-iotlab/recipes-support/rtl-sdr/rtl-sdr_git.bb
+++ b/meta-iotlab/recipes-support/rtl-sdr/rtl-sdr_git.bb
@@ -1,0 +1,25 @@
+SUMMARY = "Software to turn the RTL2832U into a SDR"
+HOMEPAGE = "http://sdr.osmocom.org/trac/wiki/rtl-sdr"
+
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
+
+DEPENDS = "libusb1"
+
+PV = "0.5.3+git${SRCPV}"
+
+SRC_URI = "git://git.osmocom.org/rtl-sdr \
+           file://0001-Do-not-store-build-system-CFLAGS-in-the-pkgconfig-fi.patch \
+          "
+SRCREV = "e3c03f738f5aef4dc51e2b741fbdb542b9cc1bb1"
+
+S = "${WORKDIR}/git"
+
+inherit autotools pkgconfig
+
+EXTRA_OECONF = "--enable-driver-detach"
+
+do_install_append() {
+	install -d ${D}${sysconfdir}/udev/rules.d
+	install -m 0644 ${S}/rtl-sdr.rules ${D}${sysconfdir}/udev/rules.d
+}


### PR DESCRIPTION
This PR adds a new recipe for managing an RTL SDR dongle with the RPI3 gateway image.

Using `rtl_tcp`, it's then possible to remotely analyze the radio data catched by the dongle. The last commit of this PR modifies the gateway code recipe because I had to modify with a `tcp-sdr-daemon` file (similar to mjpg-streamer-daemon and gateway-server-daemon).

There's an image already deployed in st-lrwan1-1 on devsaclay. For those who want to test.