### PR TITLE
Add recipe for hub-ctrl and add it to rpi3 gateway image

### DIFF
--- a/meta-iotlab/recipes-core/images/iotlab-image-gateway-rpi3.bb
+++ b/meta-iotlab/recipes-core/images/iotlab-image-gateway-rpi3.bb
@@ -6,4 +6,5 @@ IMAGE_INSTALL += " \
     kernel-modules \
     gateway-packagegroup \
     mjpg-streamer \
+    hub-ctrl \
 	"

--- a/meta-iotlab/recipes-core/images/iotlab-image-gateway-rpi3.bb
+++ b/meta-iotlab/recipes-core/images/iotlab-image-gateway-rpi3.bb
@@ -7,4 +7,5 @@ IMAGE_INSTALL += " \
     gateway-packagegroup \
     mjpg-streamer \
     hub-ctrl \
+    sudo \
 	"

--- a/meta-iotlab/recipes-extended/sudo/sudo_1.8.%.bbappend
+++ b/meta-iotlab/recipes-extended/sudo/sudo_1.8.%.bbappend
@@ -1,0 +1,5 @@
+# www-data user requires admin rights for controlling the USB ports
+# on the RPI3 gateway image
+do_install_append () {
+    echo "www-data ALL= NOPASSWD: /usr/bin/hub-ctrl" > ${D}${sysconfdir}/sudoers.d/www-data
+}

--- a/meta-iotlab/recipes-support/hub-ctrl/hub-ctrl_git.bb
+++ b/meta-iotlab/recipes-support/hub-ctrl/hub-ctrl_git.bb
@@ -1,0 +1,27 @@
+DESCRIPTION = "hub-ctrl.c: Control USB power on a port by port basis on some USB hubs"
+HOMEPAGE = "https://github.com/codazoda/hub-ctrl.c"
+SECTION = "console"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+
+SRC_URI = "git://github.com/codazoda/hub-ctrl.c;protocol=https"
+SRCREV = "42095e522859059e8a5f4ec05c1e3def01a870a9"
+
+DEPENDS = "libusb"
+
+S = "${WORKDIR}"
+
+SRCS = "${S}/git/hub-ctrl.c"
+
+LIBS += "-lusb"
+
+CFLAGS += "-W -Wall -Wextra -O2 -std=gnu11"
+
+do_compile() {
+	${CC} ${CFLAGS} ${SRCS} ${LIBS} -o ${S}/git/hub-ctrl
+}
+
+do_install() {
+	install -d ${D}${bindir}
+	install -m 755 ${S}/git/hub-ctrl ${D}${bindir}
+}


### PR DESCRIPTION
This PR adds a new recipe for [hub-ctrl](https://github.com/codazoda/hub-ctrl.c). This tools can be used to control the USB port on a RPI3 and thus can be useful to be able to power cycle an open node plugged on a RPI3.

For example:
- use the following command to power off all USB ports:
```
hub-ctrl -h 0 -P 2 -p 0
```
- use the following command to power on all USB ports:
```
hub-ctrl -h 0 -P 2 -p 1
```

The tool is already installed on nrf52dk-2 and st-lrwan1-1 in devsaclay.
