### PR TITLE
recipes-support: add recipe for Yepkit USB power control devices

### DIFF
--- a/meta-iotlab/recipes-core/images/iotlab-image-gateway-rpi3.bb
+++ b/meta-iotlab/recipes-core/images/iotlab-image-gateway-rpi3.bb
@@ -10,4 +10,5 @@ IMAGE_INSTALL += " \
     uhubctl \
     sudo \
     rtl-sdr \
+    ykush \
 	"

--- a/meta-iotlab/recipes-extended/sudo/sudo_1.8.%.bbappend
+++ b/meta-iotlab/recipes-extended/sudo/sudo_1.8.%.bbappend
@@ -3,5 +3,5 @@
 do_install_append () {
     echo "www-data ALL= NOPASSWD: /usr/bin/hub-ctrl" > ${D}${sysconfdir}/sudoers.d/www-data
     echo "www-data ALL= NOPASSWD: /usr/bin/uhubctl" >> ${D}${sysconfdir}/sudoers.d/www-data
-
+    echo "www-data ALL= NOPASSWD: /usr/bin/ykushcmd" >> ${D}${sysconfdir}/sudoers.d/www-data
 }

--- a/meta-iotlab/recipes-support/ykush/ykush/fix_makefile.patch
+++ b/meta-iotlab/recipes-support/ykush/ykush/fix_makefile.patch
@@ -1,0 +1,25 @@
+From b8e76c17ecf1dcf726cdd37146a1132adba986bb Mon Sep 17 00:00:00 2001
+From: Alexandre Abadie <alexandre.abadie@inria.fr>
+Date: Mon, 22 Oct 2018 13:53:14 +0200
+Subject: [PATCH] fix makefile
+
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 2f45e31..be3658e 100644
+--- a/Makefile
++++ b/Makefile
+@@ -3,7 +3,7 @@ OBJS = $(addprefix ykushcmd/objs/, ykushcmd.o commandParser.o ykushxs.o yk_usb_d
+ LIBS = -lhidapi-libusb -lusb-1.0 -ludev
+ LOADPATHS = -L$(CUR_PATH)/ykushcmd/linux
+ INCLUDEPATHS= -I$(CUR_PATH)/ykushcmd/linux -I$(CUR_PATH)/ykushcmd/ykushxs -I$(CUR_PATH)/ykushcmd/ykush -I$(CUR_PATH)/ykushcmd -I$(CUR_PATH)/ykushcmd/help -I$(CUR_PATH)/ykushcmd/ykush2 -I$(CUR_PATH)/ykushcmd/ykush3
+-CPP = g++
++CPP = $(CXX)
+ 
+ ykushcmd : $(OBJS)
+ 	$(CPP) $(LOADPATHS) -o bin/ykushcmd $(OBJS) $(LIBS)
+-- 
+2.17.1
+

--- a/meta-iotlab/recipes-support/ykush/ykush_git.bb
+++ b/meta-iotlab/recipes-support/ykush/ykush_git.bb
@@ -1,0 +1,20 @@
+DESCRIPTION = "Control application for Yepkit YKUSH Switchable USB Hub board."
+HOMEPAGE = "https://github.com/Yepkit/ykush"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=4b29e96047e31a3c38509d2c49b768b3"
+
+DEPENDS += "libusb"
+RDEPENDS_${PN} += "hidapi libusb1 udev"
+
+SRC_URI = "git://github.com/Yepkit/ykush.git;protocol=https \
+           file://fix_makefile.patch"
+SRCREV = "30d490423782a1d5379d1691a2539fad6ff6046d"
+PV = "git"
+S = "${WORKDIR}/git"
+
+PATCHTOOL = "git"
+
+do_install() {
+	install -d ${D}${bindir}
+	install -m 755 ${S}/bin/ykushcmd ${D}${bindir}
+}


### PR DESCRIPTION
Since controlling by software the USB ports of the RPI3 is not very reliable, I started to evaluate solutions based on external hardware.

[Yepkit](https://www.yepkit.com/home) provides boards to do this very easily with open-source software.