### PR TITLE
meta-iotlab: add recipes for converting a RPI3 gateway in a Lora gateway

### DIFF
--- a/meta-iotlab/recipes-core/images/iotlab-image-gateway-rpi3.bb
+++ b/meta-iotlab/recipes-core/images/iotlab-image-gateway-rpi3.bb
@@ -9,4 +9,8 @@ IMAGE_INSTALL += " \
     sudo \
     rtl-sdr \
     ykush \
+    lora-gateway-utils \
+    lora-packet-forwarder \
+    lora-gateway-bridge \
+    mosquitto \
 	"

--- a/meta-iotlab/recipes-extended/sudo/sudo_1.8.%.bbappend
+++ b/meta-iotlab/recipes-extended/sudo/sudo_1.8.%.bbappend
@@ -2,4 +2,5 @@
 # on the RPI3 gateway image
 do_install_append () {
     echo "www-data ALL= NOPASSWD: /usr/bin/ykushcmd" >> ${D}${sysconfdir}/sudoers.d/www-data
+    echo "www-data ALL= NOPASSWD:SETENV: /opt/lora/start.sh" >> ${D}${sysconfdir}/sudoers.d/www-data
 }

--- a/meta-iotlab/recipes-support/lora-gateway-bridge/lora-gateway-bridge/lora-gateway-bridge.init
+++ b/meta-iotlab/recipes-support/lora-gateway-bridge/lora-gateway-bridge/lora-gateway-bridge.init
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+DESC="LoRa Gateway Bridge"
+NAME=lora-gateway-bridge
+DAEMON=/opt/$NAME/$NAME
+PID_FILE=/var/run/$NAME.pid
+CONFIG_FILE=/var/config/$NAME/$NAME.toml
+
+
+function do_start {
+	start-stop-daemon \
+        --start \
+        --background \
+        --make-pidfile --pidfile "$PID_FILE" \
+		--exec $DAEMON -- --config $CONFIG_FILE
+}
+
+function do_stop {
+	start-stop-daemon \
+        --stop \
+        --retry=TERM/30/KILL/5 \
+        --pidfile "$PID_FILE" \
+        --exec "$DAEMON"
+	retval="$?"
+	sleep 1
+	return "$retval"
+}
+
+case "$1" in
+	start)
+		echo "Starting $DESC"
+		do_start
+		;;
+	stop)
+		echo "Stopping $DESC"
+		do_stop
+		;;
+	restart)
+		echo "Restarting $DESC"
+		do_stop
+		case "$?" in
+			0|1)
+				do_start
+				;;
+		esac
+		;;
+	*)
+		echo "Usage: $NAME {start|stop|restart}" >&2
+		exit 3
+		;;
+esac

--- a/meta-iotlab/recipes-support/lora-gateway-bridge/lora-gateway-bridge/lora-gateway-bridge.toml
+++ b/meta-iotlab/recipes-support/lora-gateway-bridge/lora-gateway-bridge/lora-gateway-bridge.toml
@@ -1,0 +1,161 @@
+[general]
+# debug=5, info=4, warning=3, error=2, fatal=1, panic=0
+log_level = 4
+
+
+# Configuration which relates to the packet-forwarder.
+[packet_forwarder]
+# ip:port to bind the UDP listener to
+#
+# Example: 0.0.0.0:1700 to listen on port 1700 for all network interfaces.
+# This is the listeren to which the packet-forwarder forwards its data
+# so make sure the 'serv_port_up' and 'serv_port_down' from your
+# packet-forwarder matches this port.
+udp_bind = "0.0.0.0:1700"
+
+# Skip the CRC status-check of received packets
+#
+# This is only has effect when the packet-forwarder is configured to forward
+# LoRa frames with CRC errors.
+skip_crc_check = false
+
+
+  # # Managed packet-forwarder configuration.
+  # #
+  # # By configuring one or multiple managed packet-forwarder sections, the
+  # # LoRa Gateway Bridge updates the configuration when the backend receives
+  # # a configuration change, after which it will restart the packet-forwarder.
+  # [[packet_forwarder.configuration]]
+  # # Gateway MAC.
+  # #
+  # # The LoRa Gateway Bridge will only apply the configuration updates for this
+  # # gateway MAC.
+  # mac="0102030405060708"
+
+  # # Base configuration file.
+  # #
+  # # This file will be used as base-configuration and will not be overwritten on
+  # # a configuration update. This file needs to exist and contains the base
+  # # configuration and vendor specific
+  # base_file="/var/config/lora-packet-forwarder-ap1/global_conf.json"
+
+  # # Output configuration file.
+  # #
+  # # This will be the final configuration for the packet-forwarder, containing
+  # # a merged version of the base configuration + the requested configuration
+  # # update.
+  # # Warning: this file will be overwritten on a configuration update!
+  # output_file="/var/config/lora-packet-forwarder-ap1/local_conf.json"
+
+  # # Restart command.
+  # #
+  # # This command is issued by the LoRa Gateway Bridge on a configuration
+  # # change. Make sure the LoRa Gateway Bridge process has sufficient
+  # # permissions to execute this command.
+  # restart_command="/etc/init.d/lora-packet-forwarder-ap1 restart"
+
+
+# Configuration for the MQTT backend.
+[backend.mqtt]
+# MQTT topic templates for the different MQTT topics.
+#
+# The meaning of these topics are documented at:
+# https://docs.loraserver.io/lora-gateway-bridge/use/data/
+#
+# The default values match the default expected configuration of the
+# LoRa Server MQTT backend. Therefore only change these values when
+# absolutely needed.
+# Use "{{ .MAC }}" as an substitution for the LoRa gateway MAC.
+#
+# Note that some authentication types might overwrite these templates (e.g.
+# in case of GCP Cloud IoT Core)!
+uplink_topic_template="gateway/{{ .MAC }}/rx"
+downlink_topic_template="gateway/{{ .MAC }}/tx"
+stats_topic_template="gateway/{{ .MAC }}/stats"
+ack_topic_template="gateway/{{ .MAC }}/ack"
+config_topic_template="gateway/{{ .MAC }}/config"
+
+# Payload marshaler.
+#
+# This defines how the MQTT payloads are encoded. Valid options are:
+# * v2_json:   The default LoRa Gateway Bridge v2 encoding (will be deprecated and removed in LoRa Gateway Bridge v3)
+# * protobuf:  Protobuf encoding (this will become the LoRa Gateway Bridge v3 default)
+# * json:      JSON encoding (easier for debugging, but less compact than 'protobuf')
+marshaler="v2_json"
+
+  # MQTT authentication.
+  [backend.mqtt.auth]
+  # Type defines the MQTT authentication type to use.
+  #
+  # Set this to the name of one of the sections below.
+  # Note: when the 'v2_json marhaler' is configured, the generic backend will
+  # always be used.
+  type="generic"
+
+    # Generic MQTT authentication.
+    [backend.mqtt.auth.generic]
+    # MQTT server (e.g. scheme://host:port where scheme is tcp, ssl or ws)
+    server="tcp://127.0.0.1:1883"
+
+    # Connect with the given username (optional)
+    username=""
+
+    # Connect with the given password (optional)
+    password=""
+
+    # Quality of service level
+    #
+    # 0: at most once
+    # 1: at least once
+    # 2: exactly once
+    #
+    # Note: an increase of this value will decrease the performance.
+    # For more information: https://www.hivemq.com/blog/mqtt-essentials-part-6-mqtt-quality-of-service-levels
+    qos=0
+
+    # Clean session
+    #
+    # Set the "clean session" flag in the connect message when this client
+    # connects to an MQTT broker. By setting this flag you are indicating
+    # that no messages saved by the broker for this client should be delivered.
+    clean_session=true
+
+    # Client ID
+    #
+    # Set the client id to be used by this client when connecting to the MQTT
+    # broker. A client id must be no longer than 23 characters. When left blank,
+    # a random id will be generated. This requires clean_session=true.
+    client_id=""
+
+    # CA certificate file (optional)
+    #
+    # Use this when setting up a secure connection (when server uses ssl://...)
+    # but the certificate used by the server is not trusted by any CA certificate
+    # on the server (e.g. when self generated).
+    ca_cert=""
+
+    # mqtt TLS certificate file (optional)
+    tls_cert=""
+
+    # mqtt TLS key file (optional)
+    tls_key=""
+
+    # Maximum interval that will be waited between reconnection attempts when connection is lost.
+    # Valid units are 'ms', 's', 'm', 'h'. Note that these values can be combined, e.g. '24h30m15s'.
+    max_reconnect_interval="10m0s"
+
+
+# Metrics configuration.
+[metrics]
+
+  # Metrics stored in Prometheus.
+  #
+  # These metrics expose information about the state of the LoRa Gateway Bridge
+  # instance like number of messages processed, number of function calls, etc.
+  [metrics.prometheus]
+  # Expose Prometheus metrics endpoint.
+  endpoint_enabled=false
+
+  # The ip:port to bind the Prometheus metrics server to for serving the
+  # metrics endpoint.
+  bind=""

--- a/meta-iotlab/recipes-support/lora-gateway-bridge/lora-gateway-bridge_2.6.0.bb
+++ b/meta-iotlab/recipes-support/lora-gateway-bridge/lora-gateway-bridge_2.6.0.bb
@@ -1,0 +1,32 @@
+DESCRIPTION = "LoRa Gateway Bridge"
+HOMEPAGE = "https://www.loraserver.io/"
+PRIORITY = "optional"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=5301050fd7cd58850085239d559297be"
+SRC_URI = "https://artifacts.loraserver.io/downloads/lora-gateway-bridge/lora-gateway-bridge_${PV}_linux_armv5.tar.gz \
+           file://lora-gateway-bridge.toml \
+"
+SRC_URI[md5sum] = "e7700cd481eb1c6545ae5b4bf51379cd"
+SRC_URI[sha256sum] = "4ebe707b634087951f6f99a6e1a3ffe65ff1f8bcd43ebf66e83776d3c6f5248d"
+PR = "r1"
+
+LORA_GATEWAY_BRIDGE_DIR = "/opt/lora-gateway-bridge"
+
+INSANE_SKIP_${PN} = "ldflags"
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+INHIBIT_PACKAGE_STRIP = "1"
+
+S = "${WORKDIR}"
+
+do_install() {
+    install -d ${D}${LORA_GATEWAY_BRIDGE_DIR}
+    install -m 755 lora-gateway-bridge ${D}${LORA_GATEWAY_BRIDGE_DIR}/
+
+    install -d ${D}/var/config/lora-gateway-bridge
+    install -m 0644 ${WORKDIR}/lora-gateway-bridge.toml ${D}/opt/lora-gateway-bridge/lora-gateway-bridge.toml
+}
+
+FILES_${PN} += "${LORA_GATEWAY_BRIDGE_DIR}"
+FILES_${PN}-dbg += "${LORA_GATEWAY_BRIDGE_DIR}/.debug"
+
+CONFFILES_${PN} += "/var/config/lora-gateway-bridge/lora-gateway-bridge.toml"

--- a/meta-iotlab/recipes-support/lora-gateway/lora-gateway/library.cfg
+++ b/meta-iotlab/recipes-support/lora-gateway/lora-gateway/library.cfg
@@ -1,0 +1,12 @@
+# That file will be included in the Makefile files that have hardware dependencies
+
+### Debug options ###
+# Set the DEBUG_* to 1 to activate debug mode in individual modules.
+# Warning: that makes the module *very verbose*, do not use for production
+
+DEBUG_AUX= 0
+DEBUG_SPI= 0
+DEBUG_REG= 0
+DEBUG_HAL= 1
+DEBUG_LBT= 0
+DEBUG_GPS= 0

--- a/meta-iotlab/recipes-support/lora-gateway/lora-gateway/lora-gateway-add-fpga-version-28-31-33.patch
+++ b/meta-iotlab/recipes-support/lora-gateway/lora-gateway/lora-gateway-add-fpga-version-28-31-33.patch
@@ -1,0 +1,30 @@
+diff --git a/libloragw/src/loragw_reg.c b/libloragw/src/loragw_reg.c
+index 7e396bc..478f46a 100644
+--- a/libloragw/src/loragw_reg.c
++++ b/libloragw/src/loragw_reg.c
+@@ -48,7 +48,7 @@ Maintainer: Sylvain Miermont
+ #define PAGE_ADDR        0x00
+ #define PAGE_MASK        0x03
+ 
+-const uint8_t FPGA_VERSION[] = { 31, 33 }; /* several versions could be supported */
++const uint8_t FPGA_VERSION[] = { 28, 31, 33 }; /* several versions could be supported */
+ 
+ /*
+ auto generated register mapping for C code : 11-Jul-2013 13:20:40
+@@ -415,6 +415,16 @@ bool check_fpga_version(uint8_t version) {
+     return false;
+ }
+ 
++uint8_t read_fpga_version() {
++       uint8_t u = 0;
++       uint8_t spi_stat = lgw_spi_r(lgw_spi_target, LGW_SPI_MUX_MODE1, LGW_SPI_MUX_TARGET_FPGA, loregs[LGW_VERSION].addr, &u);
++        if (spi_stat != LGW_SPI_SUCCESS) {
++            DEBUG_MSG("ERROR READING VERSION REGISTER\n");
++            return LGW_REG_ERROR;
++        }
++       return u;
++}
++
+ /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+ 
+ int reg_w_align32(void *spi_target, uint8_t spi_mux_mode, uint8_t spi_mux_target, struct lgw_reg_s r, int32_t reg_value) {

--- a/meta-iotlab/recipes-support/lora-gateway/lora-gateway/lora-gateway-add-spi-path-function.patch
+++ b/meta-iotlab/recipes-support/lora-gateway/lora-gateway/lora-gateway-add-spi-path-function.patch
@@ -1,0 +1,57 @@
+diff --git a/libloragw/inc/loragw_spi.h b/libloragw/inc/loragw_spi.h
+index fef1f48..74ef251 100644
+--- a/libloragw/inc/loragw_spi.h
++++ b/libloragw/inc/loragw_spi.h
+@@ -46,6 +46,14 @@ Maintainer: Sylvain Miermont
+ /* -------------------------------------------------------------------------- */
+ /* --- PUBLIC FUNCTIONS PROTOTYPES ------------------------------------------ */
+ 
++/* set SPI device */
++/**
++@brief LoRa concentrator SPI path configuration for spidev
++@param path pointer to spidev device
++@return LGW_SPI_SUCCESS if path is valid, LGW_SPI_ERROR if not
++*/
++int lgw_spi_set_path(const char *path);
++
+ /**
+ @brief LoRa concentrator SPI setup (configure I/O and peripherals)
+ @param spi_target_ptr pointer on a generic pointer to SPI target (implementation dependant)
+diff --git a/libloragw/src/loragw_spi.native.c b/libloragw/src/loragw_spi.native.c
+index c01ed1c..3472133 100644
+--- a/libloragw/src/loragw_spi.native.c
++++ b/libloragw/src/loragw_spi.native.c
+@@ -56,10 +56,24 @@ Maintainer: Sylvain Miermont
+ #define SPI_SPEED       8000000
+ #define SPI_DEV_PATH    "/dev/spidev0.0"
+ //#define SPI_DEV_PATH    "/dev/spidev32766.0"
++char* spi_dev_path = SPI_DEV_PATH;
+ 
+ /* -------------------------------------------------------------------------- */
+ /* --- PUBLIC FUNCTIONS DEFINITION ------------------------------------------ */
+ 
++/* set SPI device */
++int lgw_spi_set_path(const char *path) {
++    if (path) {
++        spi_dev_path = path;
++        return LGW_SPI_SUCCESS;
++    }
++    else {
++        return LGW_SPI_ERROR;
++    }
++}
++
++
++
+ /* SPI initialization and configuration */
+ int lgw_spi_open(void **spi_target_ptr) {
+     int *spi_device = NULL;
+@@ -78,7 +92,7 @@ int lgw_spi_open(void **spi_target_ptr) {
+     }
+ 
+     /* open SPI device */
+-    dev = open(SPI_DEV_PATH, O_RDWR);
++    dev = open(spi_dev_path, O_RDWR);
+     if (dev < 0) {
+         DEBUG_PRINTF("ERROR: failed to open SPI device %s\n", SPI_DEV_PATH);
+         return LGW_SPI_ERROR;

--- a/meta-iotlab/recipes-support/lora-gateway/lora-gateway/lora-gateway-v28-skip-IQ-invert.patch
+++ b/meta-iotlab/recipes-support/lora-gateway/lora-gateway/lora-gateway-v28-skip-IQ-invert.patch
@@ -1,0 +1,24 @@
+diff --git a/libloragw/src/loragw_fpga.c b/libloragw/src/loragw_fpga.c
+index fa83a2a..7e667e3 100644
+--- a/libloragw/src/loragw_fpga.c
++++ b/libloragw/src/loragw_fpga.c
+@@ -144,11 +144,14 @@ int lgw_fpga_configure(uint32_t tx_notch_freq) {
+         return LGW_REG_ERROR;
+     }
+ 
+-    /* Required for Semtech AP2 reference design */
+-    x  = lgw_fpga_reg_w(LGW_FPGA_CTRL_INVERT_IQ, 1);
+-    if (x != LGW_REG_SUCCESS) {
+-        DEBUG_MSG("ERROR: Failed to configure FPGA polarity\n");
+-        return LGW_REG_ERROR;
++
++    if (read_fpga_version() > 28) {
++        /* Required for Semtech AP2 reference design and AP1.5 > v28 */
++        x  = lgw_fpga_reg_w(LGW_FPGA_CTRL_INVERT_IQ, 1);
++        if (x != LGW_REG_SUCCESS) {
++            DEBUG_MSG("ERROR: Failed to configure FPGA polarity\n");
++            return LGW_REG_ERROR;
++        }
+     }
+ 
+     /* Configure TX notch filter */

--- a/meta-iotlab/recipes-support/lora-gateway/lora-gateway_5.0.1.bb
+++ b/meta-iotlab/recipes-support/lora-gateway/lora-gateway_5.0.1.bb
@@ -1,0 +1,51 @@
+DESCRIPTION = "Driver/HAL to build a gateway using a concentrator board based on Semtech SX1301"
+HOMEPAGE = "https://github.com/Lora-net/lora_gateway"
+PRIORITY = "optional"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=a2bdef95625509f821ba00460e3ae0eb"
+PR = "r2"
+
+SRC_URI = "git://github.com/Lora-net/lora_gateway.git;protocol=git \
+           file://library.cfg \
+           file://lora-gateway-add-fpga-version-28-31-33.patch \
+           file://lora-gateway-v28-skip-IQ-invert.patch \
+           file://lora-gateway-add-spi-path-function.patch \
+"
+
+SRCREV = "a955619271b5d0a46d32e08150acfbc1eed183b7"
+
+S = "${WORKDIR}/git"
+CFLAGS += "-Iinc -I."
+
+do_configure_append() {
+    cp ${WORKDIR}/library.cfg ${S}/libloragw/library.cfg
+}
+
+do_compile() {
+    oe_runmake
+}
+
+do_install() {
+    install -d ${D}${libdir}/lora
+    install -d ${D}${includedir}/lora
+
+    install -m 0644 libloragw/libloragw.a ${D}${libdir}/lora
+    install -m 0644 libloragw/library.cfg ${D}${libdir}/lora
+    install -m 0644 libloragw/inc/* ${D}${includedir}/lora
+
+    install -d ${D}/opt/lora-gateway/gateway-utils
+    install -m 0755 libloragw/test_* ${D}/opt/lora-gateway/gateway-utils/
+    install -m 0755 util_pkt_logger/util_pkt_logger ${D}/opt/lora-gateway/gateway-utils/
+    install -m 0755 util_spectral_scan/util_spectral_scan ${D}/opt/lora-gateway/gateway-utils/
+    install -m 0755 util_spi_stress/util_spi_stress ${D}/opt/lora-gateway/gateway-utils/
+    install -m 0755 util_tx_test/util_tx_test ${D}/opt/lora-gateway/gateway-utils/
+    install -m 0755 util_tx_continuous/util_tx_continuous ${D}/opt/lora-gateway/gateway-utils/
+    install -m 0755 util_lbt_test/util_lbt_test ${D}/opt/lora-gateway/gateway-utils/
+}
+
+PACKAGES += "${PN}-utils ${PN}-utils-dbg"
+
+FILES_${PN}-staticdev = "${libdir}/lora"
+FILES_${PN}-utils = "/opt/lora-gateway/gateway-utils/*"
+FILES_${PN}-utils-dbg = "/opt/lora-gateway/gateway-utils/.debug"
+FILES_${PN}-dev = "${includedir}/lora ${libdir}/lora/library.cfg"

--- a/meta-iotlab/recipes-support/lora-packet-forwarder/lora-packet-forwarder/README.md
+++ b/meta-iotlab/recipes-support/lora-packet-forwarder/lora-packet-forwarder/README.md
@@ -1,0 +1,38 @@
+
+
+(c) Senet, Inc 2016
+
+
+
+3rd Party Licenses
+------------------
+
+This software incorporates the lora_gateway software which requires the
+following statement to be included in its distribution.
+
+Copyright (c) 2013, SEMTECH S.A.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of the Semtech corporation nor the
+    names of its contributors may be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL SEMTECH S.A. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+

--- a/meta-iotlab/recipes-support/lora-packet-forwarder/lora-packet-forwarder/global_conf.json
+++ b/meta-iotlab/recipes-support/lora-packet-forwarder/lora-packet-forwarder/global_conf.json
@@ -1,0 +1,226 @@
+{
+    "SX1301_conf": {
+        "lorawan_public": true,
+        "clksrc": 1, /* radio_1 provides clock to concentrator */
+        "lbt_cfg": {
+            "enable": false,
+            "rssi_target": -80, /* dBm */
+            "chan_cfg":[ /* 8 channels maximum */
+                { "freq_hz": 867100000, "scan_time_us": 128 },
+                { "freq_hz": 867300000, "scan_time_us": 5000 },
+                { "freq_hz": 867500000, "scan_time_us": 128 },
+                { "freq_hz": 869525000, "scan_time_us": 128 }
+            ],
+            "sx127x_rssi_offset": -4 /* dB */
+        },
+        "antenna_gain": 0, /* antenna gain, in dBi */
+        "radio_0": {
+            "enable": true,
+            "type": "SX1257",
+            "freq": 867500000,
+            "rssi_offset": -166.0,
+            "tx_enable": true,
+            "tx_notch_freq": 129000, /* [126..250] KHz */
+            "tx_freq_min": 863000000,
+            "tx_freq_max": 870000000
+        },
+        "radio_1": {
+            "enable": true,
+            "type": "SX1257",
+            "freq": 868500000,
+            "rssi_offset": -166.0,
+            "tx_enable": false
+        },
+        "chan_multiSF_0": {
+            /* Lora MAC channel, 125kHz, all SF, 868.1 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": -400000
+        },
+        "chan_multiSF_1": {
+            /* Lora MAC channel, 125kHz, all SF, 868.3 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": -200000
+        },
+        "chan_multiSF_2": {
+            /* Lora MAC channel, 125kHz, all SF, 868.5 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": 0
+        },
+        "chan_multiSF_3": {
+            /* Lora MAC channel, 125kHz, all SF, 867.1 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": -400000
+        },
+        "chan_multiSF_4": {
+            /* Lora MAC channel, 125kHz, all SF, 867.3 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": -200000
+        },
+        "chan_multiSF_5": {
+            /* Lora MAC channel, 125kHz, all SF, 867.5 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": 0
+        },
+        "chan_multiSF_6": {
+            /* Lora MAC channel, 125kHz, all SF, 867.7 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": 200000
+        },
+        "chan_multiSF_7": {
+            /* Lora MAC channel, 125kHz, all SF, 867.9 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": 400000
+        },
+        "chan_Lora_std": {
+            /* Lora MAC channel, 250kHz, SF7, 868.3 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": -200000,
+            "bandwidth": 250000,
+            "spread_factor": 7
+        },
+        "chan_FSK": {
+            /* FSK 50kbps channel, 868.8 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": 300000,
+            "bandwidth": 125000,
+            "datarate": 50000
+        },
+        "tx_lut_0": {
+            /* TX gain table, index 0 */
+            "pa_gain": 0,
+            "mix_gain": 8,
+            "rf_power": -6,
+            "dig_gain": 0
+        },
+        "tx_lut_1": {
+            /* TX gain table, index 1 */
+            "pa_gain": 0,
+            "mix_gain": 10,
+            "rf_power": -3,
+            "dig_gain": 0
+        },
+        "tx_lut_2": {
+            /* TX gain table, index 2 */
+            "pa_gain": 0,
+            "mix_gain": 12,
+            "rf_power": 0,
+            "dig_gain": 0
+        },
+        "tx_lut_3": {
+            /* TX gain table, index 3 */
+            "pa_gain": 1,
+            "mix_gain": 8,
+            "rf_power": 3,
+            "dig_gain": 0
+        },
+        "tx_lut_4": {
+            /* TX gain table, index 4 */
+            "pa_gain": 1,
+            "mix_gain": 10,
+            "rf_power": 6,
+            "dig_gain": 0
+        },
+        "tx_lut_5": {
+            /* TX gain table, index 5 */
+            "pa_gain": 1,
+            "mix_gain": 12,
+            "rf_power": 10,
+            "dig_gain": 0
+        },
+        "tx_lut_6": {
+            /* TX gain table, index 6 */
+            "pa_gain": 1,
+            "mix_gain": 13,
+            "rf_power": 11,
+            "dig_gain": 0
+        },
+        "tx_lut_7": {
+            /* TX gain table, index 7 */
+            "pa_gain": 2,
+            "mix_gain": 9,
+            "rf_power": 12,
+            "dig_gain": 0
+        },
+        "tx_lut_8": {
+            /* TX gain table, index 8 */
+            "pa_gain": 1,
+            "mix_gain": 15,
+            "rf_power": 13,
+            "dig_gain": 0
+        },
+        "tx_lut_9": {
+            /* TX gain table, index 9 */
+            "pa_gain": 2,
+            "mix_gain": 10,
+            "rf_power": 14,
+            "dig_gain": 0
+        },
+        "tx_lut_10": {
+            /* TX gain table, index 10 */
+            "pa_gain": 2,
+            "mix_gain": 11,
+            "rf_power": 16,
+            "dig_gain": 0
+        },
+        "tx_lut_11": {
+            /* TX gain table, index 11 */
+            "pa_gain": 3,
+            "mix_gain": 9,
+            "rf_power": 20,
+            "dig_gain": 0
+        },
+        "tx_lut_12": {
+            /* TX gain table, index 12 */
+            "pa_gain": 3,
+            "mix_gain": 10,
+            "rf_power": 23,
+            "dig_gain": 0
+        },
+        "tx_lut_13": {
+            /* TX gain table, index 13 */
+            "pa_gain": 3,
+            "mix_gain": 11,
+            "rf_power": 25,
+            "dig_gain": 0
+        },
+        "tx_lut_14": {
+            /* TX gain table, index 14 */
+            "pa_gain": 3,
+            "mix_gain": 12,
+            "rf_power": 26,
+            "dig_gain": 0
+        },
+        "tx_lut_15": {
+            /* TX gain table, index 15 */
+            "pa_gain": 3,
+            "mix_gain": 14,
+            "rf_power": 27,
+            "dig_gain": 0
+        }
+    },
+
+    "gateway_conf": {
+        /* change with default server address/ports, or overwrite in local_conf.json */
+        "server_address": "localhost",
+        "serv_port_up": 1680,
+        "serv_port_down": 1680,
+        /* adjust the following parameters for your network */
+        "keepalive_interval": 10,
+        "stat_interval": 30,
+        "push_timeout_ms": 100,
+        /* forward only valid packets */
+        "forward_crc_valid": true,
+        "forward_crc_error": false,
+        "forward_crc_disabled": false
+    }
+}

--- a/meta-iotlab/recipes-support/lora-packet-forwarder/lora-packet-forwarder/local_conf.json
+++ b/meta-iotlab/recipes-support/lora-packet-forwarder/lora-packet-forwarder/local_conf.json
@@ -1,0 +1,8 @@
+{
+    "gateway_conf": {
+        "gateway_ID": "AA555A0000000000",
+        "server_address": "127.0.0.1",
+        "serv_port_up": 1700,
+        "serv_port_down": 1700
+    }
+}

--- a/meta-iotlab/recipes-support/lora-packet-forwarder/lora-packet-forwarder/lora-packet-forwarder-add-no-header-option.patch
+++ b/meta-iotlab/recipes-support/lora-packet-forwarder/lora-packet-forwarder/lora-packet-forwarder-add-no-header-option.patch
@@ -1,0 +1,17 @@
+diff --git a/lora_pkt_fwd/src/lora_pkt_fwd.c b/lora_pkt_fwd/src/lora_pkt_fwd.c
+index 31a3743..c15b191 100644
+--- a/lora_pkt_fwd/src/lora_pkt_fwd.c
++++ b/lora_pkt_fwd/src/lora_pkt_fwd.c
+@@ -2143,6 +2143,12 @@ void thread_down(void) {
+                 txpkt.no_crc = (bool)json_value_get_boolean(val);
+             }
+ 
++            /* Parse "No Header" flag (optional field) */
++            val = json_object_get_value(txpk_obj,"nhdr");
++            if (val != NULL) {
++                txpkt.no_header = (bool)json_value_get_boolean(val);
++            }
++
+             /* parse target frequency (mandatory) */
+             val = json_object_get_value(txpk_obj,"freq");
+             if (val == NULL) {

--- a/meta-iotlab/recipes-support/lora-packet-forwarder/lora-packet-forwarder/lora-packet-forwarder-add-spi-dev-path.patch
+++ b/meta-iotlab/recipes-support/lora-packet-forwarder/lora-packet-forwarder/lora-packet-forwarder-add-spi-dev-path.patch
@@ -1,0 +1,38 @@
+diff --git a/lora_pkt_fwd/src/lora_pkt_fwd.c b/lora_pkt_fwd/src/lora_pkt_fwd.c
+index 31a3743..a8c8f01 100644
+--- a/lora_pkt_fwd/src/lora_pkt_fwd.c
++++ b/lora_pkt_fwd/src/lora_pkt_fwd.c
+@@ -119,6 +119,7 @@ static bool fwd_nocrc_pkt = false; /* packets with NO PAYLOAD CRC are NOT forwar
+ /* network configuration variables */
+ static uint64_t lgwm = 0; /* Lora gateway MAC address */
+ static char serv_addr[64] = STR(DEFAULT_SERVER); /* address of the server (host name or IPv4/IPv6) */
++static char spi_device_path[64] = {0} ; /* custom SPI device path */
+ static char serv_port_up[8] = STR(DEFAULT_PORT_UP); /* server port for upstream traffic */
+ static char serv_port_down[8] = STR(DEFAULT_PORT_DW); /* server port for downstream traffic */
+ static int keepalive_time = DEFAULT_KEEPALIVE; /* send a PULL_DATA request every X seconds, negative = disabled */
+@@ -645,6 +646,13 @@ static int parse_gateway_configuration(const char * conf_file) {
+         MSG("INFO: server hostname or IP address is configured to \"%s\"\n", serv_addr);
+     }
+ 
++    /* spi device path (optional) */
++    str = json_object_get_string(conf_obj, "spi_device");
++    if (str != NULL) {
++        strncpy(spi_device_path, str, sizeof(spi_device_path)-1);
++        MSG("INFO: SPI device is configured to \"%s\"\n", spi_device_path);
++    }
++
+     /* get up and down ports (optional) */
+     val = json_object_get_value(conf_obj, "serv_port_up");
+     if (val != NULL) {
+@@ -1092,6 +1100,11 @@ int main(void)
+     }
+     freeaddrinfo(result);
+ 
++    /* set custom SPI device path if configured */
++    if (strlen(spi_device_path) > 0)
++        lgw_spi_set_path(spi_device_path);
++
++
+     /* starting the concentrator */
+     i = lgw_start();
+     if (i == LGW_HAL_SUCCESS) {

--- a/meta-iotlab/recipes-support/lora-packet-forwarder/lora-packet-forwarder/lora-packet-forwarder-custom-conf-dir.patch
+++ b/meta-iotlab/recipes-support/lora-packet-forwarder/lora-packet-forwarder/lora-packet-forwarder-custom-conf-dir.patch
@@ -1,0 +1,49 @@
+From 843d63c38e7be8bbb593c9ca6226c0cebd68a2fb Mon Sep 17 00:00:00 2001
+From: Alexandre Abadie <alexandre.abadie@inria.fr>
+Date: Sun, 10 Mar 2019 11:44:54 +0100
+Subject: [PATCH] packet_forwarder: allow getting local config from other
+ directory
+
+---
+ lora_pkt_fwd/src/lora_pkt_fwd.c | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/lora_pkt_fwd/src/lora_pkt_fwd.c b/lora_pkt_fwd/src/lora_pkt_fwd.c
+index 801f28d..4e87469 100644
+--- a/lora_pkt_fwd/src/lora_pkt_fwd.c
++++ b/lora_pkt_fwd/src/lora_pkt_fwd.c
+@@ -981,7 +981,20 @@ int main(void)
+ 
+     /* configuration file related */
+     char *global_cfg_path= "global_conf.json"; /* contain global (typ. network-wide) configuration */
+-    char *local_cfg_path = "local_conf.json"; /* contain node specific configuration, overwrite global parameters for parameters that are defined in both */
++    char *local_cfg_path;
++    char *local_cfg_filename = "local_conf.json";
++    char *cfg_dir = getenv("CFG_DIR");
++    if (cfg_dir != NULL) {
++        MSG("INFO: using custom local configuration dir %s\n", cfg_dir);
++        local_cfg_path = malloc(strlen(cfg_dir) + strlen(local_cfg_filename) + 2);
++        sprintf(local_cfg_path, "%s/%s", cfg_dir, local_cfg_filename);
++    }
++    else {
++        local_cfg_path = malloc(strlen(local_cfg_filename) + 1);
++        sprintf(local_cfg_path, "%s", local_cfg_filename);
++    }
++    MSG("INFO: using local configuration file %s\n", local_cfg_path);
++
+     char *debug_cfg_path = "debug_conf.json"; /* if present, all other configuration files are ignored */
+ 
+     /* threads */
+@@ -1082,6 +1095,9 @@ int main(void)
+             parse_SX1301_configuration(local_cfg_path);
+             parse_gateway_configuration(local_cfg_path);
+         }
++        else {
++            MSG("INFO: cannot find local configuration file %s\n", local_cfg_path);
++        }
+     } else if (access(local_cfg_path, R_OK) == 0) { /* if there is only a local conf, parse it and that's all */
+         MSG("INFO: found local configuration file %s, parsing it\n", local_cfg_path);
+         x = parse_SX1301_configuration(local_cfg_path);
+-- 
+2.19.1
+

--- a/meta-iotlab/recipes-support/lora-packet-forwarder/lora-packet-forwarder/lora-packet-forwarder-parse-config-params-when-radio-disabled.patch
+++ b/meta-iotlab/recipes-support/lora-packet-forwarder/lora-packet-forwarder/lora-packet-forwarder-parse-config-params-when-radio-disabled.patch
@@ -1,0 +1,25 @@
+diff --git a/lora_pkt_fwd/src/lora_pkt_fwd.c b/lora_pkt_fwd/src/lora_pkt_fwd.c
+index 1c54d57..92f25e3 100644
+--- a/lora_pkt_fwd/src/lora_pkt_fwd.c
++++ b/lora_pkt_fwd/src/lora_pkt_fwd.c
+@@ -471,7 +471,8 @@ static int parse_SX1301_configuration(const char * conf_file) {
+         }
+         if (rfconf.enable == false) { /* radio disabled, nothing else to parse */
+             MSG("INFO: radio %i disabled\n", i);
+-        } else  { /* radio enabled, will parse the other parameters */
++        }
++//        } else  { /* radio enabled, will parse the other parameters */
+             snprintf(param_name, sizeof param_name, "radio_%i.freq", i);
+             rfconf.freq_hz = (uint32_t)json_object_dotget_number(conf_obj, param_name);
+             snprintf(param_name, sizeof param_name, "radio_%i.rssi_offset", i);
+@@ -505,8 +506,8 @@ static int parse_SX1301_configuration(const char * conf_file) {
+             } else {
+                 rfconf.tx_enable = false;
+             }
+-            MSG("INFO: radio %i enabled (type %s), center frequency %u, RSSI offset %f, tx enabled %d, tx_notch_freq %u\n", i, str, rfconf.freq_hz, rfconf.rssi_offset, rfconf.tx_enable, rfconf.tx_notch_freq);
+-        }
++            MSG("INFO: radio %i %sabled (type %s), center frequency %u, RSSI offset %f, tx enabled %d, tx_notch_freq %u\n", i, (rfconf.enable?"en":"dis"), str, rfconf.freq_hz, rfconf.rssi_offset, rfconf.tx_enable, rfconf.tx_notch_freq);
++//        }
+         /* all parameters parsed, submitting configuration to the HAL */
+         if (lgw_rxrf_setconf(i, rfconf) != LGW_HAL_SUCCESS) {
+             MSG("ERROR: invalid configuration for radio %i\n", i);

--- a/meta-iotlab/recipes-support/lora-packet-forwarder/lora-packet-forwarder/lora-packet-forwarder-remove-jit-power-check.patch
+++ b/meta-iotlab/recipes-support/lora-packet-forwarder/lora-packet-forwarder/lora-packet-forwarder-remove-jit-power-check.patch
@@ -1,0 +1,24 @@
+diff --git a/lora_pkt_fwd/src/lora_pkt_fwd.c b/lora_pkt_fwd/src/lora_pkt_fwd.c
+index 1c54d57..1e74d7f 100644
+--- a/lora_pkt_fwd/src/lora_pkt_fwd.c
++++ b/lora_pkt_fwd/src/lora_pkt_fwd.c
+@@ -2360,19 +2360,6 @@ void thread_down(void) {
+                 jit_result = JIT_ERROR_TX_FREQ;
+                 MSG("ERROR: Packet REJECTED, unsupported frequency - %u (min:%u,max:%u)\n", txpkt.freq_hz, tx_freq_min[txpkt.rf_chain], tx_freq_max[txpkt.rf_chain]);
+             }
+-            if (jit_result == JIT_ERROR_OK) {
+-                for (i=0; i<txlut.size; i++) {
+-                    if (txlut.lut[i].rf_power == txpkt.rf_power) {
+-                        /* this RF power is supported, we can continue */
+-                        break;
+-                    }
+-                }
+-                if (i == txlut.size) {
+-                    /* this RF power is not supported */
+-                    jit_result = JIT_ERROR_TX_POWER;
+-                    MSG("ERROR: Packet REJECTED, unsupported RF power for TX - %d\n", txpkt.rf_power);
+-                }
+-            }
+ 
+             /* insert packet to be sent into JIT queue */
+             if (jit_result == JIT_ERROR_OK) {

--- a/meta-iotlab/recipes-support/lora-packet-forwarder/lora-packet-forwarder/start.sh
+++ b/meta-iotlab/recipes-support/lora-packet-forwarder/lora-packet-forwarder/start.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Reset iC880a PIN
+SX1301_RESET_BCM_PIN=25
+echo "$SX1301_RESET_BCM_PIN"  > /sys/class/gpio/export 
+echo "out" > /sys/class/gpio/gpio$SX1301_RESET_BCM_PIN/direction 
+echo "0"   > /sys/class/gpio/gpio$SX1301_RESET_BCM_PIN/value 
+sleep 0.2
+echo "1"   > /sys/class/gpio/gpio$SX1301_RESET_BCM_PIN/value 
+sleep 0.2
+echo "0"   > /sys/class/gpio/gpio$SX1301_RESET_BCM_PIN/value
+sleep 0.2
+echo "$SX1301_RESET_BCM_PIN" > /sys/class/gpio/unexport 
+
+# Fire up the forwarder.
+cd /opt/lora
+./lora_pkt_fwd

--- a/meta-iotlab/recipes-support/lora-packet-forwarder/lora-packet-forwarder_4.0.1.bb
+++ b/meta-iotlab/recipes-support/lora-packet-forwarder/lora-packet-forwarder_4.0.1.bb
@@ -1,0 +1,55 @@
+DESCRIPTION = "LoRa Packet Forwarder"
+HOMEPAGE = "https://github.com/Lora-net/packet_forwarder"
+PRIORITY = "optional"
+SECTION = "console/utils"
+# Semtech license is a modified BSD-style license
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=22af7693d7b76ef0fc76161c4be76c45"
+DEPENDS = "lora-gateway"
+RDEPENDS_${PN} += "bash"
+PR = "r12"
+
+SRCREV = "v${PV}"
+
+SRC_URI = "git://github.com/Lora-net/packet_forwarder.git;protocol=git \
+           file://global_conf.json \
+           file://local_conf.json \
+           file://start.sh \
+           file://lora-packet-forwarder-add-spi-dev-path.patch \
+           file://lora-packet-forwarder-remove-jit-power-check.patch \
+"
+
+S = "${WORKDIR}/git"
+B = "${S}"
+
+LORA_DIR = "/opt/lora"
+
+export LGW_PATH = "${STAGING_LIBDIR}/lora"
+export LGW_INC = "${STAGING_INCDIR}/lora"
+
+CFLAGS += "-I${LGW_INC} -Iinc -I. -std=gnu11"
+
+do_compile() {
+  oe_runmake
+}
+
+do_install() {
+  install -d ${D}${LORA_DIR}
+  install -m 755 lora_pkt_fwd/lora_pkt_fwd ${D}${LORA_DIR}/
+  install -m 755 ${WORKDIR}/global_conf.json ${D}${LORA_DIR}/
+  install -m 755 ${WORKDIR}/local_conf.json ${D}${LORA_DIR}/
+  install -m 755 ${WORKDIR}/start.sh ${D}${LORA_DIR}/
+
+  install -d ${D}${LORA_DIR}/forwarder-utils
+  install -m 755 util_sink/util_sink ${D}${LORA_DIR}/forwarder-utils/
+  install -m 755 util_ack/util_ack ${D}${LORA_DIR}/forwarder-utils/
+  install -m 755 util_tx_test/util_tx_test ${D}${LORA_DIR}/forwarder-utils/
+}
+
+FILES_${PN} += "${LORA_DIR}"
+FILES_${PN}-dbg += "${LORA_DIR}/.debug ${LORA_DIR}/forwarder-utils/.debug"
+
+# disable this on purpose for dev purposes
+do_rm_work() {
+  echo "skipping"
+}

--- a/meta-iotlab/recipes-support/lora-packet-forwarder/lora-packet-forwarder_4.0.1.bb
+++ b/meta-iotlab/recipes-support/lora-packet-forwarder/lora-packet-forwarder_4.0.1.bb
@@ -17,6 +17,7 @@ SRC_URI = "git://github.com/Lora-net/packet_forwarder.git;protocol=git \
            file://start.sh \
            file://lora-packet-forwarder-add-spi-dev-path.patch \
            file://lora-packet-forwarder-remove-jit-power-check.patch \
+           file://lora-packet-forwarder-custom-conf-dir.patch \
 "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
- add lora_gateway_driver and lora_pkt_forwarder recipes
- add lora_gateway_bridge recipe
- allow sudo for www-data user with /opt/lora/start.sh (start the lora_pkt_forwarder)
- build mosquitto, lora_gateway_bridge and lora_pkt_forwarder in RPI3 gateway image