### PR TITLE
add ptpd daemon support with slaveonly configuration file

### DIFF
--- a/meta-iotlab/recipes-core/images/iotlab-image.inc
+++ b/meta-iotlab/recipes-core/images/iotlab-image.inc
@@ -45,9 +45,6 @@ IMAGE_INSTALL +="               \
         socat                   \
         iputils                 \
         rsync                   \
-        ntp                     \
-        ntp-waitsync            \
-        ntp-utils               \
         python                  \
         python-pyserial         \
         python-dev              \

--- a/meta-iotlab/recipes-core/images/iotlab-image.inc
+++ b/meta-iotlab/recipes-core/images/iotlab-image.inc
@@ -146,6 +146,9 @@ IMAGE_INSTALL += "              \
         avrdude                 \
         \
         "
+IMAGE_INSTALL += "              \
+        ptpd                    \
+	"
 # Broken
 IMAGE_INSTALL_BROKEN += "       \
         libgcov-dev             \

--- a/meta-iotlab/recipes-extended/ptpd/ptpd/ptpd.conf
+++ b/meta-iotlab/recipes-extended/ptpd/ptpd/ptpd.conf
@@ -1,0 +1,50 @@
+; /etc/ptpd.conf
+; interface has to be specified
+ptpengine:interface=eth0
+
+; PTP domain
+ptpengine:domain=42
+
+; available presets are slaveonly, masteronly and masterslave (full IEEE 1588 implementation)
+ptpengine:preset=slaveonly
+; multicast for both sync and delay requests - use hybrid for unicast delay requests
+ptpengine:ip_mode=multicast
+
+; when enabled, instead of sockets, libpcap is used to receive (sniff) and send (inject) packets.
+; on low latency hardware such as 10GE NICs this can provide results close to hardware-assisted PTP
+ptpengine:use_libpcap=y
+
+; go into panic mode for 10 minutes instead of resetting the clock
+ptpengine:panic_mode=y
+ptpengine:panic_mode_duration=10
+
+; store observed drift in a file
+clock:drift_handling=file
+
+; update online statistics every 5 seconds
+global:statistics_update_interval=5
+
+; wait 5 statistics intervals for one-way delay to stabilise
+ptpengine:calibration_delay=5
+
+; log file, event log only. if timing statistics are needed, see statistics_file
+global:log_file=/var/log/ptpd2.log
+; log file up to 5M
+global:log_file_max_size=5000
+; rotate logs up to 5 files
+global:log_file_max_files=5
+
+; status file providing an overview of ptpd's operation and statistics
+global:log_status=y
+
+; uncomment this to log a timing log like in previous ptpd versions
+;global:statistics_file=/var/log/ptpd2.stats
+
+; on multi-core systems it is recommended to bind ptpd to a single core
+;global:cpuaffinity_cpucore=0
+
+; use DSCP 46 for expedited forwarding over ipv4 networks
+ptpengine:ip_dscp=46
+
+; always keep a new line in the end
+

--- a/meta-iotlab/recipes-extended/ptpd/ptpd/ptpd.default
+++ b/meta-iotlab/recipes-extended/ptpd/ptpd/ptpd.default
@@ -1,0 +1,7 @@
+# /etc/default/ptpd
+
+# pid file
+PTPD_PID_FILE="/var/run/ptpd2.lock"
+
+# Add command line options for ptpd
+PTPD_OPTIONS="-c /etc/ptpd.conf"

--- a/meta-iotlab/recipes-extended/ptpd/ptpd/ptpd.init
+++ b/meta-iotlab/recipes-extended/ptpd/ptpd/ptpd.init
@@ -1,0 +1,200 @@
+#!/bin/bash
+
+#
+# ptpd:         Precision Time protocol server (IEEE 1588)
+#
+# chkconfig: 2345 59 73
+#
+# description:      The PTP daemon (PTPd) implements the Precision Time
+#           protocol (PTP) as defined by the IEEE 1588 standard.
+#           PTP was developed to provide very precise time
+#           coordination of LAN connected computers.
+
+DAEMON=/usr/bin/ptpd2
+prog=PTPd
+RETVAL=0
+PATH=/sbin:/usr/local/bin:$PATH
+DAEMON_DESC="IEEE 1588 Precision Time Protocol (v2) daemon"
+
+
+. /etc/init.d/functions
+
+if test -e /etc/default/ptpd ; then
+
+    . /etc/default/ptpd
+fi
+
+
+
+start() {
+	status -p $PTPD_PID_FILE $DAEMON > /dev/null 2>&1
+	RETVAL=$?
+	if [ "$RETVAL" -eq "0" ]
+	then
+		echo "$prog already running (PID `cat $PTPD_PID_FILE`)."
+		exit 0
+	fi
+
+	echo -n "Starting $DAEMON_DESC..."
+
+		$DAEMON $PTPD_OPTIONS
+		sleep 1 
+		status -p $PTPD_PID_FILE $DAEMON > /dev/null 2>&1
+		RETVAL=$?
+	if [ "$RETVAL" -eq "0" ] 
+	then 
+		echo_success
+	else
+		echo_failure
+	fi
+
+	echo
+}
+
+checkstatus() {
+	status -p $PTPD_PID_FILE $DAEMON > /dev/null 2>&1 	
+	RETVAL=$?
+	if [ "$RETVAL" -eq "0" ] 
+	then 
+	        if test -e $PTPD_PID_FILE ; then
+			echo "$prog is running (PID `cat $PTPD_PID_FILE`)."
+		fi
+	else
+			echo "$prog is not running."
+			RETVAL=3
+	fi
+
+	exit $RETVAL
+}
+
+showinfo() {
+	status -p $PTPD_PID_FILE $DAEMON > /dev/null 2>&1 	
+	RETVAL=$?
+	if [ "$RETVAL" -eq "0" ] 
+	then 
+	        if test -e $PTPD_PID_FILE ; then
+			echo "$prog is running (PID `cat $PTPD_PID_FILE`)."
+
+			taskset -pc `cat $PTPD_PID_FILE`
+		    
+			if test -e $PTPD_STATUS_FILE; then
+
+				cat $PTPD_STATUS_FILE
+
+			fi
+
+		fi
+	else
+			echo "$prog is not running."
+			RETVAL=3
+	fi
+
+	exit $RETVAL
+}
+
+
+checkconfig() {
+
+	$DAEMON -k $PTPD_OPTIONS
+	RETVAL=$?
+}
+
+stop() {
+	status -p $PTPD_PID_FILE $DAEMON > /dev/null 2>&1 	
+	RETVAL=$?
+   if [ "$RETVAL" -ne "0" ] 
+   then 
+   	echo "$prog not running."
+	else
+		killproc -p $PTPD_PID_FILE $DAEMON
+		RETVAL=$?
+		if [ "$RETVAL" -eq "0" ] 
+		then 
+			echo "Stopping $DAEMON_DESC...`echo_success`"
+		else
+			echo "Stopping $DAEMON_DESC...`echo_failure`"
+		fi
+	fi
+}
+
+reload() {
+
+	    checkconfig
+	    if [ "$RETVAL" -ne "0" ]; then
+		echo "Reloading $prog: `echo_failure`"
+		exit $RETVAL
+	    fi
+		echo -n $"Reloading $prog: "
+	    killproc -p $PTPD_PID_FILE $DAEMON -HUP
+	    RETVAL=$?
+	    echo
+}
+
+help() {
+
+        echo $"Usage: $0 {start|stop|restart|reload|checkconfig|condrestart|status|info}"
+        exit 1                         
+}
+
+if [ -z "$1" ]
+then
+    help
+fi
+
+case "$1" in
+    start)
+    start
+    RETVAL=$?
+    ;;
+
+    status)
+    checkstatus
+    RETVAL=$?
+    ;;
+
+    info)
+    showinfo
+    RETVAL=$?
+    ;;
+
+
+    restart)
+    stop
+	 sleep 1
+    start
+    RETVAL=$?
+    ;;
+
+    reload)
+    reload
+    RETVAL=$?
+
+    ;;
+
+    stop)
+    stop
+	 exit 0
+    ;;
+
+    checkconfig)
+    checkconfig
+    RETVAL=$?
+    ;;
+
+
+    condrestart)
+        if [ -f PID_FILE ]; then
+            stop
+            start
+            RETVAL=$?
+        fi
+        ;;
+    *)
+
+	echo $"Usage: $0 {start|stop|restart|reload|checkconfig|condrestart|status}"
+	RETVAL=3
+    ;;
+
+esac
+
+exit $RETVAL

--- a/meta-iotlab/recipes-extended/ptpd/ptpd_%.bbappend
+++ b/meta-iotlab/recipes-extended/ptpd/ptpd_%.bbappend
@@ -1,0 +1,20 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://ptpd.conf"
+SRC_URI += "file://ptpd.default"
+SRC_URI += "file://ptpd.init"
+
+#inherit update-rc.d
+#INITSCRIPT_PACKAGES = "${PN}"
+
+do_install_append() {
+  install -d ${D}${sysconfdir}/init.d
+  install -m 0755 ${WORKDIR}/ptpd.init ${D}${sysconfdir}/init.d/ptpd
+  install -d ${D}${sysconfdir}/default
+  install -m 0644 ${WORKDIR}/ptpd.default ${D}${sysconfdir}/default/ptpd
+  install -m 0644 ${WORKDIR}/ptpd.conf ${D}${sysconfdir}/ptpd.conf
+}
+
+FILES_${PN} += "${sysconfdir}/ptpd.conf"
+FILES_${PN} += "${sysconfdir}/init.d/ptpd"
+FILES_${PN} += "${sysconfdir}/default/ptpd"


### PR DESCRIPTION
Currently, ntp daemon is still running by default. You should first stop ntp:

```
    /etc/init.d/ntp stop
```

Then start ptp

```
    /etc/init.d/ptp start
```