### PR TITLE
meta-iotlab/openocd: upgrade to recent version (07/2020)

### DIFF
--- a/meta-iotlab/recipes-devtools/openocd/openocd-git.bb
+++ b/meta-iotlab/recipes-devtools/openocd/openocd-git.bb
@@ -9,21 +9,24 @@ PR = "r1"
 DEPENDS = ""
 DEPENDS += "libftdi"
 DEPENDS += "libusb1"
-DEPENDS += "libjaylink"
-DEPENDS += "jimtcl"
 DEPENDS += "hidapi"
 DEPENDS += "texinfo-native"
 
-## ##################################################
-## ##################################################
-
-# Use git version master: issues when using source code
-SRCREV = "05e0d633bad9e8b0bdfaf16fc76ab1f9d9419d8b"
-
 PV = "gitr${SRCPV}"
 
-SRC_URI = "git://github.com/ntfreak/openocd.git;protocol=https"
-SRC_URI += "file://0001-static-library.patch"
+SRC_URI = " \
+    git://repo.or.cz/openocd.git;protocol=http;name=openocd \
+    git://repo.or.cz/r/git2cl.git;protocol=http;destsuffix=tools/git2cl;name=git2cl \
+    git://repo.or.cz/r/jimtcl.git;protocol=http;destsuffix=git/jimtcl;name=jimtcl \
+    git://repo.or.cz/r/libjaylink.git;protocol=http;destsuffix=git/src/jtag/drivers/libjaylink;name=libjaylink \
+    file://0001-static-library.patch \
+"
+
+SRCREV_FORMAT = "openocd"
+SRCREV_openocd = "7c88e76a76588fa0e3ab645adfc46e8baff6a3e4"
+SRCREV_git2cl = "8373c9f74993e218a08819cbcdbab3f3564bbeba"
+SRCREV_jimtcl = "0aa0fb4e3a38d38a49de9eb585d93d63a370dcf6"
+SRCREV_libjaylink = "dce11b89e85179a92a0fe3a90d2693ca891ed646"
 
 S = "${WORKDIR}/git"
 
@@ -37,7 +40,7 @@ FILES_${PN}     += "/opt/openocd-dev"
 
 # inherit autotools
 # Don't use out of tree build
-inherit autotools-brokensep pkgconfig
+inherit autotools-brokensep pkgconfig gettext
 
 EXTRA_OECONF = ""
 EXTRA_OECONF += " --disable-werror "
@@ -49,30 +52,11 @@ EXTRA_OECONF += " --enable-maintainer-mode "
 # nrf52dk
 EXTRA_OECONF += " --enable-jlink "
 
-# disable libjaylink (no submodule)
-EXTRA_OECONF += " --disable-internal-libjaylink "
-
 PARAMS_BUILD  = " --enable-largefile --disable-nls --enable-ipv6 --with-sysroot=${STAGING_DIR_TARGET} --with-libtool-sysroot=${STAGING_DIR_TARGET} "
-PARAMS_BUILD += " --disable-internal-jimtcl "
 
 PARAMS_CROSS  = " --build=${BUILD_SYS} --host=${HOST_SYS} --target=${TARGET_SYS} "
 PARAMS_CROSS += " --libdir=${STAGING_DIR_TARGET}/lib "
 PARAMS_INST   = " --prefix=/opt/openocd-dev "
-
-## --enable-ipv6
-## --libdir=${STAGING_DIR_TARGET}/lib
-##
-## export BUILD_SYS=x86_64-linux
-## export HOST_SYS=arm-oe-linux-gnueabi
-## export TARGET_SYS=arm-oe-linux-gnueabi
-## export STAGING_DIR_TARGET=/home/volume6/dev.oe/openembedded-core/build.gw/tmp-eglibc/sysroots/var-som-am35
-##
-## ./configure --build=x86_64-linux --host=arm-oe-linux-gnueabi --target=arm-oe-linux-gnueabi \
-## --libdir=/home/volume6/dev.oe/openembedded-core/build.gw/tmp-eglibc/sysroots/var-som-am35/lib \
-## --enable-largefile --disable-nls \
-## --with-sysroot=/home/volume6/dev.oe/openembedded-core/build.gw/tmp-eglibc/sysroots/var-som-am35 \
-## --with-libtool-sysroot=/home/volume6/dev.oe/openembedded-core/build.gw/tmp-eglibc/sysroots/var-som-am35 \
-## --enable-ft2232_libftdi --disable-ftdi2232 --disable-ftd2xx --disable-werror --disable-internal-jimtcl
 
 do_configure() {
     # Build jimtcl in a separate package !!!!!!! got segfault when not doing it
@@ -80,7 +64,7 @@ do_configure() {
     ./bootstrap nosubmodule
     ## oe_runconf does *not* work and must not be used here
     ./configure ${PARAMS_INST} ${PARAMS_CROSS} ${PARAMS_BUILD} ${EXTRA_OECONF}
-    #oe_runconf ./configure ${PARAMS_CROSS} ${PARAMS_BUILD} ${EXTRA_OECONF}
+    #oe_runconf ${PARAMS_INST} ${PARAMS_CROSS} ${PARAMS_BUILD} ${EXTRA_OECONF}
 }
 
 ## ##################################################


### PR DESCRIPTION
I briefly tested it on devsaclay by installing the ipk on a gateway and it works ok.

This version allows the integration of a big bunch of new open_nodes in iot-lab.