### PR TITLE
Bump version of avrdude + add avarice

### DIFF
--- a/meta-iotlab/recipes-core/images/iotlab-image.inc
+++ b/meta-iotlab/recipes-core/images/iotlab-image.inc
@@ -143,8 +143,6 @@ IMAGE_INSTALL += "              \
         \
         curl                    \
         \
-        avrdude                 \
-        \
         "
 # Broken
 IMAGE_INSTALL_BROKEN += "       \

--- a/meta-iotlab/recipes-core/packagegroups/base-packagegroup.bb
+++ b/meta-iotlab/recipes-core/packagegroups/base-packagegroup.bb
@@ -4,6 +4,8 @@ LICENSE = "GPLv2"
 inherit packagegroup
 
 RDEPENDS_${PN} += " \
+    avarice \
+    avrdude \
     base-files \
     base-config \
     initrdscripts-settime \

--- a/meta-iotlab/recipes-devtools/avarice/avarice_git.bb
+++ b/meta-iotlab/recipes-devtools/avarice/avarice_git.bb
@@ -1,0 +1,25 @@
+DESCRIPTION = "AVaRICE is a program which interfaces the GNU Debugger GDB with the AVR JTAG ICE available from Atmel."
+HOMEPAGE = "http://avarice.sourceforge.net/"
+SECTION = "console"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=0636e73ff0215e8d672dc4c32c317bb3"
+
+SRC_URI[md5sum] = "346ec2e46393a54ac152b95abf1d9850"
+SRC_URI[sha256sum] = "c6804668dfa96b23185dfe2e8239089af4e4ae0b11aa7435bebb28c3260ede41"
+
+PR = "r1"
+# Use git version master
+SRC_URI = "git://github.com/multiplemonomials/avarice.git;protocol=https"
+SRCREV = "9a0e122fb0d74ab69d9d5922ca8f6b157ae2aa1d"
+
+S = "${WORKDIR}/git"
+
+DEPENDS = "libusb libftdi hidapi"
+
+inherit cmake
+
+do_install_append () {
+    rm -rf ${D}/usr/bin/ice-gdb
+    rm -rf ${D}/usr/data/gdb-avarice-script
+    rm -rf ${D}/usr/data
+}

--- a/meta-iotlab/recipes-devtools/avrdude/avrdude_svn.bb
+++ b/meta-iotlab/recipes-devtools/avrdude/avrdude_svn.bb
@@ -1,0 +1,13 @@
+SUMMARY = "AVRDUDE is a utility to download/upload/manipulate the ROM and EEPROM contents of AVR microcontrollers using the in-system programming technique (ISP)."
+
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=4f51bb496ef8872ccff73f440f2464a8"
+
+DEPENDS = "libusb elfutils hidapi libftdi readline"
+
+inherit autotools
+
+PV = "6.3+svn${SRCPV}"
+SRC_URI = "svn://svn.savannah.nongnu.org/svn/avrdude/;protocol=http;module=trunk;rev=1425"
+
+S = "${WORKDIR}/trunk/avrdude"


### PR DESCRIPTION
- Use the very last version of avrdude: allows for programming new atmega boards with an on-board programmer (and a 802.15.4 radio)
- Add avarice which is debug tool for AVR.