### PR TITLE
Add rasperrypi2 support with 4.14 kernel for dunfell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,16 @@ ifeq ($(TARGET), a8)
 
   # We also build a mtd-rw version of the kernel for A8
   EXTRA_BUILDS = build-kernel-mtd-rw
+else ifeq ($(TARGET), rpi2)
+  BUILD_DIR = build-rpi2
+  TARGET_ARCH = cortexa7t2hf-neon-vfpv4
+  TARGET_IMG = raspberrypi2
+  KERNEL_IMG = zImage
+
+  # Use a mapping between image target of make with image name in yocto
+  iotlab-image = iotlab-image-rpi2
+  iotlab-image-gateway = iotlab-image-gateway-rpi2
+  iotlab-image-autotest = iotlab-image-rpi2-autotest
 else ifeq ($(TARGET), rpi3)
   BUILD_DIR = build-rpi3
   TARGET_ARCH = cortexa7t2hf-neon-vfpv4

--- a/build-rpi2/conf/bblayers.conf
+++ b/build-rpi2/conf/bblayers.conf
@@ -1,0 +1,21 @@
+# LAYER_CONF_VERSION is increased each time build/conf/bblayers.conf
+# changes incompatibly
+POKY_BBLAYERS_CONF_VERSION = "2"
+
+BBPATH = "${TOPDIR}"
+BBFILES ?= ""
+
+BBLAYERS ?= " \
+  ${TOPDIR}/../poky/meta \
+  ${TOPDIR}/../poky/meta-poky \
+  ${TOPDIR}/../meta-openembedded/meta-oe \
+  ${TOPDIR}/../meta-openembedded/meta-networking \
+  ${TOPDIR}/../meta-openembedded/meta-python \
+  ${TOPDIR}/../meta-java/ \
+  ${TOPDIR}/../meta-iotlab/ \
+  ${TOPDIR}/../meta-raspberrypi/ \
+  "
+BBLAYERS_NON_REMOVABLE ?= " \
+  ${TOPDIR}/../poky/meta \
+  ${TOPDIR}/../poky/meta-poky \
+  "

--- a/build-rpi2/conf/local.conf
+++ b/build-rpi2/conf/local.conf
@@ -1,0 +1,118 @@
+LICENSE_FLAGS_WHITELIST = "IoT-LAB"
+DISTRO ?= "iotlab"
+
+# local repository with sources
+SOURCE_MIRROR_URL ?= "file://${TOPDIR}/../downloads/"
+INHERIT += "own-mirrors"
+BB_GENERATE_MIRROR_TARBALLS = "1"
+# BB_NO_NETWORK = "1"
+
+# cleanup after build of sources
+INHERIT += "rm_work"
+
+# Enable console
+ENABLE_UART = "1"
+
+# Enable camera
+VIDEO_CAMERA = "1"
+
+#MACHINE ??= "qemuarm"
+MACHINE ?= "raspberrypi2"
+# use compressed image 
+KERNEL_IMAGETYPE = "zImage"
+
+IMAGE_FSTYPES += "tar.gz"
+
+PREFERRED_VERSION_linux-raspberrypi ?= "4.14%"
+
+KERNEL_DEVICETREE_remove = "overlays/disable-bt.dtbo overlays/miniuart-bt.dtbo overlays/rpi-poe.dtbo bcm2710-rpi-3-b.dtb bcm2710-rpi-3-b-plus.dtb bcm2711-rpi-4-b.dtb bcm2708-rpi-cm.dtb bcm2710-rpi-cm3.dtb"
+
+# Where to place downloads
+#DL_DIR ?= "${TOPDIR}/downloads"
+
+# Where to place shared-state files
+#SSTATE_DIR ?= "${TOPDIR}/sstate-cache"
+
+# Where to place the build output
+#TMPDIR = "${TOPDIR}/tmp"
+
+# Package Management configuration
+PACKAGE_CLASSES ?= "package_ipk"
+
+BB_NUMBER_THREADS ?= "16"
+PARALLEL_MAKE ?= "-j 16"
+
+# Extra image configuration defaults
+#
+# The EXTRA_IMAGE_FEATURES variable allows extra packages to be added to the generated 
+# images. Some of these options are added to certain image types automatically. The
+# variable can contain the following options:
+#  "dbg-pkgs"       - add -dbg packages for all installed packages
+#                     (adds symbol information for debugging/profiling)
+#  "dev-pkgs"       - add -dev packages for all installed packages
+#                     (useful if you want to develop against libs in the image)
+#  "ptest-pkgs"     - add -ptest packages for all ptest-enabled packages
+#                     (useful if you want to run the package test suites)
+#  "tools-sdk"      - add development tools (gcc, make, pkgconfig etc.)
+#  "tools-debug"    - add debugging tools (gdb, strace)
+#  "eclipse-debug"  - add Eclipse remote debugging support
+#  "tools-profile"  - add profiling tools (oprofile, exmap, lttng, valgrind)
+#  "tools-testapps" - add useful testing tools (ts_print, aplay, arecord etc.)
+#  "debug-tweaks"   - make an image suitable for development
+#                     e.g. ssh root access has a blank password
+# There are other application targets that can be used here too, see
+# meta/classes/image.bbclass and meta/classes/core-image.bbclass for more details.
+# We default to enabling the debugging tweaks.
+#EXTRA_IMAGE_FEATURES = "read-only-rootfs"
+EXTRA_IMAGE_FEATURES = ""
+
+#
+# Additional image features
+#
+# The following is a list of additional classes to use when building images which
+# enable extra features. Some available options which can be included in this variable 
+# are:
+#   - 'buildstats' collect build statistics
+#   - 'image-mklibs' to reduce shared library files size for an image
+#   - 'image-prelink' in order to prelink the filesystem image
+#   - 'image-swab' to perform host system intrusion detection
+# NOTE: if listing mklibs & prelink both, then make sure mklibs is before prelink
+# NOTE: mklibs also needs to be explicitly enabled for a given image, see local.conf.extended
+USER_CLASSES ?= "buildstats image-mklibs image-prelink"
+
+# Interactive shell configuration
+PATCHRESOLVE = "noop"
+
+# Disk Space Monitoring during the build
+#
+# Monitor the disk space during the build. If there is less that 1GB of space or less
+# than 100K inodes in any key build location (TMPDIR, DL_DIR, SSTATE_DIR), gracefully
+# shutdown the build. If there is less that 100MB or 1K inodes, perform a hard abort
+# of the build. The reason for this is that running completely out of space can corrupt
+# files and damages the build in ways which may not be easily recoverable.
+BB_DISKMON_DIRS = "\
+    STOPTASKS,${TMPDIR},1G,100K \
+    STOPTASKS,${DL_DIR},1G,100K \
+    STOPTASKS,${SSTATE_DIR},1G,100K \
+    ABORT,${TMPDIR},100M,1K \
+    ABORT,${DL_DIR},100M,1K \
+    ABORT,${SSTATE_DIR},100M,1K" 
+
+# CONF_VERSION is increased each time build/conf/ changes incompatibly and is used to
+# track the version of this file when it was generated. This can safely be ignored if
+# this doesn't mean anything to you.
+CONF_VERSION = "1"
+
+GLIBC_GENERATE_LOCALES = "en_GB.UTF-8 en_US.UTF-8"
+
+### OpenJDK Preferences
+PREFERRED_PROVIDER_virtual/java-initial-native = "cacao-initial-native"
+PREFERRED_PROVIDER_virtual/java-native = "cacao-native"
+PREFERRED_PROVIDER_virtual/javac-native = "ecj-bootstrap-native"
+PREFERRED_PROVIDER_java2-runtime = "openjdk-8-jre"
+PREFERRED_PROVIDER_java2-vm = "openjdk-8-jre"
+
+# Fix build issue "The following packages could not be configured offline and
+# rootfs is read-only"
+# source: https://forums.xilinx.com/t5/Embedded-Linux/Read-only-filesystem/td-p/826414
+SERIAL_CONSOLES_CHECK_forcevariable = ""

--- a/build-rpi2/conf/local.conf
+++ b/build-rpi2/conf/local.conf
@@ -28,7 +28,7 @@ PREFERRED_VERSION_linux-raspberrypi ?= "4.14%"
 KERNEL_DEVICETREE_remove = "overlays/disable-bt.dtbo overlays/miniuart-bt.dtbo overlays/rpi-poe.dtbo bcm2710-rpi-3-b.dtb bcm2710-rpi-3-b-plus.dtb bcm2711-rpi-4-b.dtb bcm2708-rpi-cm.dtb bcm2710-rpi-cm3.dtb"
 
 # Where to place downloads
-#DL_DIR ?= "${TOPDIR}/downloads"
+DL_DIR ?= "${TOPDIR}/downloads"
 
 # Where to place shared-state files
 #SSTATE_DIR ?= "${TOPDIR}/sstate-cache"

--- a/meta-iotlab/recipes-core/images/iotlab-image-gateway-rpi2.bb
+++ b/meta-iotlab/recipes-core/images/iotlab-image-gateway-rpi2.bb
@@ -1,0 +1,15 @@
+DESCRIPTION = "IoT-LAB image for RPI2 gateway"
+include iotlab-image.inc
+
+# Include modules in rootfs
+IMAGE_INSTALL += " \
+    kernel-modules \
+    gateway-packagegroup \
+    mjpg-streamer \
+    sudo \
+    rtl-sdr \
+    ykush \
+    linux-firmware-bcm43430 \
+    linux-firmware-rtl8192cu \
+    lldpd \
+    "

--- a/meta-iotlab/recipes-core/images/iotlab-image-rpi2-autotest.bb
+++ b/meta-iotlab/recipes-core/images/iotlab-image-rpi2-autotest.bb
@@ -1,0 +1,11 @@
+include iotlab-image.inc
+
+EXTRA_IMAGE_FEATURES += "debug-tweaks"
+
+# Include modules in rootfs
+IMAGE_INSTALL += " \
+		kernel-modules \
+		linux-node-packagegroup \
+		linux-firmware-bcm43430 \
+    		linux-firmware-rtl8192cu \
+		"

--- a/meta-iotlab/recipes-core/images/iotlab-image-rpi2.bb
+++ b/meta-iotlab/recipes-core/images/iotlab-image-rpi2.bb
@@ -1,0 +1,9 @@
+include iotlab-image.inc
+
+# Include modules in rootfs
+IMAGE_INSTALL += " \
+		kernel-modules \
+		linux-node-packagegroup \
+    		linux-firmware-bcm43430 \
+    		linux-firmware-rtl8192cu \
+		"


### PR DESCRIPTION
Fix kernel crash with kernel 4.19 and 5.4 for a raspberry pi 2 board with multiple USB devices.